### PR TITLE
Could not working `FROM` fields then fixed.

### DIFF
--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -13,7 +13,7 @@ Dockerfile <- R6::R6Class("Dockerfile",
                         Dockerfile = character(),
                         ## Either from a file, or from a character vector
                         initialize = function(FROM = "rocker/r-base", AS = NULL){
-                          self$Dockerfile <- create_dockerfile("rocker/r-base", AS)
+                          self$Dockerfile <- create_dockerfile(FROM, AS)
                         },
                         RUN = function(cmd){
                           self$Dockerfile <- c(self$Dockerfile, add_run(cmd))


### PR DESCRIPTION
Currently, both CRAN and GitHub versions had `Dockerfile$new()`'s `FROM` option were unable to change.

<details>

``` r
install.packages("dockerfiler")
#> 
#> The downloaded binary packages are in
#>  /var/folders/0x/mb63hycs4k30_7httqyxh2rr0000gn/T//RtmplVlPBc/downloaded_packages
library(dockerfiler)
my_dock <- Dockerfile$new(FROM = "rocker/tidyverse")
my_dock
#> FROM rocker/r-base
```

``` r
remotes::install_github("ColinFay/dockerfiler")
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo ColinFay/dockerfiler@master
#> Skipping 1 packages ahead of CRAN: rlang
library(dockerfiler)
my_dock <- Dockerfile$new(FROM = "rocker/tidyverse")
my_dock
#> FROM rocker/r-base
```

Created on 2018-03-13 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

</details>

This patch will allow to specify any dokcer image.

<details>

``` r
library(dockerfiler)
my_dock <- Dockerfile$new(FROM = "rocker/tidyverse")
my_dock
#> FROM rocker/tidyverse
```

Created on 2018-03-13 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

</details>

p.s. Thanks for nice package development. I’m fanboy R and Docker too 🐳