### PR TITLE
Renv2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,12 @@
   untouched.
 - `dock_from_renv()` no longer installs `remotes` when `renv_version = NULL`,
   since `remotes` was only needed for the `install_version()` path.
-
+- feat: `dock_from_renv()` introduces a build-arg `RENV_PATHS_CACHE` (default
+  `/root/.cache/R/renv`), propagated as an `ENV` variable, for configurable
+  renv cache paths.
+- feat: `dock_from_renv()` cache mount is now
+  `--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE}` and uses
+  `renv::restore(clean = FALSE)` to speed up and harden the Docker build.
 
 # dockerfiler 0.2.5
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -84,6 +84,9 @@ dock_from_renv <- function(
     ),
     AS = AS
   )
+  dock$ARG("RENV_PATHS_CACHE=/root/.cache/R/renv")
+  dock$ENV(key = "RENV_PATHS_CACHE",value = "${RENV_PATHS_CACHE}")
+
   if (!is.null(user)) {
     dock$USER(user)
   }
@@ -243,7 +246,8 @@ dock_from_renv <- function(
   }
 
   dock$COPY(basename(lockfile), "renv.lock")
-  dock$RUN("--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv R -e 'renv::restore()'")
+  dock$RUN("--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} R -e 'renv::restore(clean = FALSE)'")
+
   dock
 }
 

--- a/dockerfiler.Rproj
+++ b/dockerfiler.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: aea0fc85-ff2f-4b78-a34d-39f668860543
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/Dockerfile
+++ b/tests/testthat/Dockerfile
@@ -1,7 +1,0 @@
-FROM rocker/r-base:4.1.0
-RUN apt-get update -y && apt-get install -y  make  zlib1g-dev  pandoc  libicu-dev && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/
-RUN echo "options(renv.config.pak.enabled = TRUE, repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl', Ncpus = 4)" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site
-RUN R -e 'install.packages(c("renv","remotes"))'
-COPY renv.lock renv.lock
-RUN R -e 'renv::restore()'

--- a/tests/testthat/renv_Dockerfile
+++ b/tests/testthat/renv_Dockerfile
@@ -1,8 +1,10 @@
 FROM rocker/verse:4.1.2
+ARG RENV_PATHS_CACHE=/root/.cache/R/renv
+ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"
 RUN fake sys reqs
 RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/
 RUN echo "options(renv.config.pak.enabled = FALSE, repos = fake repos, download.file.method = 'libcurl', Ncpus = 4)" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site
 RUN R -e 'install.packages("remotes")'
 RUN R -e 'remotes::install_version("renv", version = "0.0.0")'
 COPY renv.lock renv.lock
-RUN --mount=type=cache,id=renv-cache,target=/root/.cache/R/renv R -e 'renv::restore()'
+RUN --mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} R -e 'renv::restore(clean = FALSE)'


### PR DESCRIPTION
- feat: In dock_from_renv, introduce build-arg RENV_PATHS_CACHE (default /root/.cache/R/renv) and propagate it as an ENV variable for configurable renv cache paths.
- feat: In dock_from_renv, update cache mounting to --mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} and use renv::restore(clean=FALSE) to speed up and harden the Docker build.
