### PR TITLE
Skip remotes install in dock_from_renv when renv_version = NULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
   `packagemanager.rstudio.com` and internal mirrors) are preserved on
   rewrite. Multi-entry `repos` vectors and non-PPM repos are left
   untouched.
+- `dock_from_renv()` no longer installs `remotes` when `renv_version = NULL`,
+  since `remotes` was only needed for the `install_version()` path.
 
 
 # dockerfiler 0.2.5

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -237,7 +237,9 @@ dock_from_renv <- function(
       dock$RUN(install_renv_string)
 
   } else {
-    dock$RUN("R -e 'install.packages(c(\"renv\",\"remotes\"))'")
+    # renv_version = NULL: use the latest renv from the configured repos.
+    # `remotes` is only needed for the install_version() path above.
+    dock$RUN("R -e 'install.packages(\"renv\")'")
   }
 
   dock$COPY(basename(lockfile), "renv.lock")

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -171,9 +171,9 @@ for (renv_version in list(NULL,"banana","missing")){
   }
 socle_install_version <- "remotes::install_version\\(\"renv\", version = \""
   if (lf == the_lockfile &    is.null(renv_version)) {
-    test_string <- 'install.packages\\(c\\(\"renv\",\"remotes\"))'
+    test_string <- 'install.packages\\(\"renv\"\\)'
   } else if (lf == the_lockfile1.0.0 & is.null(renv_version)) {
-    test_string <- 'install.packages\\(c\\(\"renv\",\"remotes\"))'
+    test_string <- 'install.packages\\(\"renv\"\\)'
   } else if (lf == the_lockfile &  renv_version == "banana") {
     test_string <-  paste0(socle_install_version,"banana"  ,"\"\\)")
   } else if (lf == the_lockfile1.0.0 & renv_version == "banana") {
@@ -190,6 +190,13 @@ socle_install_version <- "remotes::install_version\\(\"renv\", version = \""
   expect_true( any(   grepl(test_string , out$Dockerfile)    ),
                info = paste(lf," & ",renv_version))
 
+  if (is.null(renv_version)) {
+    # When using the latest renv, `remotes` must not be installed at all.
+    expect_false(
+      any(grepl("remotes", out$Dockerfile)),
+      info = paste(lf, " & NULL renv_version => no remotes")
+    )
+  }
 
 }}
 


### PR DESCRIPTION
## Summary

When `dock_from_renv()` is called with `renv_version = NULL` ("install the latest renv from the configured repos"), the generated Dockerfile previously installed both `renv` *and* `remotes`:

```dockerfile
RUN R -e 'install.packages(c("renv","remotes"))'
```

But `remotes` is only needed in the *other* branch — the one where `renv_version` is a specific version and the Dockerfile uses `remotes::install_version()` to pin it. In the `NULL` branch, `remotes` is dead weight: ~15 transitive dependencies (`pkgbuild`, `pkgload`, `processx`, `callr`, `desc`, `withr`, `gh`, `httr`, ...) downloaded and installed at build time for zero runtime use.

This PR replaces the `NULL` branch with `install.packages("renv")` alone. The `renv_version != NULL` branch is unchanged.

## Backward compatibility

- Strictly backward-compatible. Callers that don't pass `renv_version = NULL` are unaffected.
- The roxygen statement `If you set it to NULL, the latest available version of renv will be used.` remains accurate.
- If a downstream stage (e.g. a derived image's `FROM`) was relying on `remotes` being present in the resulting image, that breakage is documented in `NEWS.md`. The fix on their end is a one-liner: `RUN R -e 'install.packages("remotes")'`.

## Test plan

- [x] Existing test `dock_from_renv works with specific renv` updated: the regex for the `renv_version = NULL` cases (both lockfiles in the loop) flips from `install.packages\(c\("renv","remotes"\)\)` to `install.packages\("renv"\)`.
- [x] New gated assertion: when `renv_version = NULL`, the Dockerfile must not contain `remotes` anywhere (`expect_false(any(grepl("remotes", out$Dockerfile)))`).
- [x] `devtools::test(filter = "dock_from_renv")` -> 18 PASS / 0 FAIL.
- [x] `R CMD check` clean (only environmental qpdf warning + clock NOTE on the build sandbox).