### PR TITLE
Auto-configure PPM binary builds in dock_from_renv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dockerfiler
 Title: Easy Dockerfile Creation from R
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
     person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,17 @@
 # dockerfiler (development version)
 
 - `dock_from_renv()` now auto-configures the generated Dockerfile to fetch
-  Linux binaries from Posit Package Manager when the `repos` argument points
-  to PPM. Four things happen: the PPM URL is rewritten to include
-  `__linux__/$VERSION_CODENAME/` (resolved at image build time from
-  `/etc/os-release`); `HTTPUserAgent` is set to the strict format PPM
-  requires; `renv.config.repos.override` is set so that `renv::restore()`
-  uses PPM instead of the lockfile's repo URL; and the RUN is prefixed with
-  `. /etc/os-release && `. Non-PPM repos are left untouched.
+  Linux binaries from Posit Package Manager when `repos` is a single
+  CRAN-keyed PPM URL. Four things happen: the PPM URL is rewritten to
+  include `__linux__/$VERSION_CODENAME/` (resolved at image build time
+  from `/etc/os-release`) when it was `cran` or `cran/latest`;
+  `HTTPUserAgent` is set to the strict format PPM requires;
+  `renv.config.repos.override` is set so that `renv::restore()` uses PPM
+  instead of the lockfile's repo URL; and the RUN is prefixed with
+  `. /etc/os-release && ` when the line uses `$VERSION_CODENAME`.
+  User-pinned codenames and snapshot-date URLs (e.g. `cran/2024-01-15`)
+  are preserved as-is. Multi-entry `repos` vectors and non-PPM repos are
+  left untouched.
 
 
 # dockerfiler 0.2.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# dockerfiler (development version)
+# dockerfiler 0.2.6
 
 - `dock_from_renv()` now auto-configures the generated Dockerfile to fetch
   Linux binaries from Posit Package Manager when `repos` is a single
@@ -10,8 +10,10 @@
   instead of the lockfile's repo URL; and the RUN is prefixed with
   `. /etc/os-release && ` when the line uses `$VERSION_CODENAME`.
   User-pinned codenames and snapshot-date URLs (e.g. `cran/2024-01-15`)
-  are preserved as-is. Multi-entry `repos` vectors and non-PPM repos are
-  left untouched.
+  are preserved as-is. The user's PPM scheme and host (including
+  `packagemanager.rstudio.com` and internal mirrors) are preserved on
+  rewrite. Multi-entry `repos` vectors and non-PPM repos are left
+  untouched.
 
 
 # dockerfiler 0.2.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# dockerfiler (development version)
+
+- `dock_from_renv()` now auto-configures the generated Dockerfile to fetch
+  Linux binaries from Posit Package Manager when the `repos` argument points
+  to PPM. Four things happen: the PPM URL is rewritten to include
+  `__linux__/$VERSION_CODENAME/` (resolved at image build time from
+  `/etc/os-release`); `HTTPUserAgent` is set to the strict format PPM
+  requires; `renv.config.repos.override` is set so that `renv::restore()`
+  uses PPM instead of the lockfile's repo URL; and the RUN is prefixed with
+  `. /etc/os-release && `. Non-PPM repos are left untouched.
+
+
 # dockerfiler 0.2.5
 
 - feat: allow multistage dockerfile creation

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -252,7 +252,7 @@ dock_from_renv <- function(
 #' line previously written by `dock_from_renv()`:
 #'  1. CRAN URL rewritten to the `__linux__/$VERSION_CODENAME/` PPM variant
 #'     (codename resolved from /etc/os-release at image build time). Skipped
-#'     if the user already pinned `__linux__/<codename>/` themselves.
+#'     if the user already pinned a codename or a snapshot date.
 #'  2. `HTTPUserAgent` added in the strict format required by PPM
 #'     (`R (<version> <platform> <arch> <os>)`). Without it, PPM falls back
 #'     to source even with a `__linux__/` URL.
@@ -260,45 +260,54 @@ dock_from_renv <- function(
 #'     `renv::restore()` uses PPM instead of the repo URL recorded in the
 #'     lockfile (renv prefers lockfile repos by default; without this
 #'     override, fixes 1 and 2 are bypassed during `restore()`).
-#'  4. The `RUN` is prefixed with `. /etc/os-release && ` so that
-#'     `$VERSION_CODENAME` is defined when the shell evaluates the line.
+#'  4. The `RUN` is prefixed with `. /etc/os-release && ` when (and only
+#'     when) `$VERSION_CODENAME` ends up in the line.
 #'
-#' Only applies when at least one URL in `repos` looks like PPM.
+#' Only fires when `repos` is a single-entry vector named `CRAN` whose URL
+#' is on PPM. Multi-entry vectors and other shapes are intentionally left
+#' untouched -- rebuilding a multi-key `repos = c(...)` block robustly is
+#' out of scope.
 #' @noRd
 .patch_rprofile_for_ppm <- function(dock, repos) {
-  if (!any(grepl("packagemanager\\.(posit|rstudio)\\.(co|com)", repos))) {
+  ppm_pattern <- "^https?://packagemanager\\.(posit|rstudio)\\.(co|com)/"
+  if (length(repos) != 1L || !identical(names(repos), "CRAN")) {
     return(invisible(NULL))
   }
+  user_url <- repos[["CRAN"]]
+  if (!grepl(ppm_pattern, user_url)) {
+    return(invisible(NULL))
+  }
+
   rps_idx <- grep("tee /usr/local/lib/R/etc/Rprofile\\.site", dock$Dockerfile)
   if (length(rps_idx) != 1L) return(invisible(NULL))
 
   patched <- dock$Dockerfile[rps_idx]
+  ppm_codename_url <- "https://packagemanager.posit.co/cran/__linux__/$VERSION_CODENAME/latest"
 
-  ppm_url <- "https://packagemanager.posit.co/cran/__linux__/$VERSION_CODENAME/latest"
-
-  # Don't rewrite if the user already pinned a Linux codename in the URL.
-  if (!grepl("__linux__/", patched)) {
+  # Only rewrite when the URL is the bare `cran` or `cran/latest` form.
+  # Anything else (already-pinned codename, snapshot date, custom path)
+  # is left alone so we never silently clobber the user's intent.
+  url_suffix <- sub("^.*/cran/?", "", user_url)
+  rewrite_url <- url_suffix == "" || url_suffix == "latest"
+  if (rewrite_url) {
     patched <- sub(
       "repos = c\\(CRAN = '[^']*'\\)",
-      sprintf("repos = c(CRAN = '%s')", ppm_url),
+      sprintf("repos = c(CRAN = '%s')", ppm_codename_url),
       patched
     )
+    override_url <- ppm_codename_url
+  } else {
+    override_url <- user_url
   }
 
   # Force renv::restore() to use the configured PPM URL instead of the repos
   # recorded in the lockfile (cf. ?renv::config -- option declared as
-  # "primarily useful for deployment / continuous integration"). Without this,
-  # the URL rewrite above is bypassed during restore().
+  # "primarily useful for deployment / continuous integration"). Without
+  # this, the URL rewrite above is bypassed during restore().
   if (!grepl("renv\\.config\\.repos\\.override", patched)) {
-    # Reuse whatever URL ended up on the `repos = c(CRAN = '...')` line so the
-    # override matches even when the user supplied their own PPM URL.
-    cran_url <- sub(
-      ".*repos = c\\(CRAN = '([^']*)'\\).*", "\\1",
-      patched
-    )
     repos_override <- sprintf(
       ", renv.config.repos.override = c(CRAN = '%s')",
-      cran_url
+      override_url
     )
     patched <- sub(
       "(renv\\.config\\.pak\\.enabled = (TRUE|FALSE))",
@@ -323,7 +332,10 @@ dock_from_renv <- function(
     )
   }
 
-  if (!grepl("/etc/os-release", patched)) {
+  # Only prefix `. /etc/os-release && ` when the line actually references
+  # $VERSION_CODENAME -- otherwise the prefix is dead weight.
+  if (grepl("\\$VERSION_CODENAME", patched) &&
+      !grepl("/etc/os-release", patched)) {
     patched <- sub("^RUN ", "RUN . /etc/os-release && ", patched)
   }
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -282,20 +282,29 @@ dock_from_renv <- function(
   if (length(rps_idx) != 1L) return(invisible(NULL))
 
   patched <- dock$Dockerfile[rps_idx]
-  ppm_codename_url <- "https://packagemanager.posit.co/cran/__linux__/$VERSION_CODENAME/latest"
+
+  # Strip a single trailing slash so `cran/latest/` matches `cran/latest`.
+  user_url_norm <- sub("/$", "", user_url)
+  # Preserve the user's scheme + host (so a `packagemanager.rstudio.com`
+  # URL or an internal mirror is not silently rewritten to posit.co).
+  user_host_prefix <- sub("/cran(/.*)?$", "", user_url_norm)
 
   # Only rewrite when the URL is the bare `cran` or `cran/latest` form.
   # Anything else (already-pinned codename, snapshot date, custom path)
   # is left alone so we never silently clobber the user's intent.
-  url_suffix <- sub("^.*/cran/?", "", user_url)
+  url_suffix <- sub("^.*/cran/?", "", user_url_norm)
   rewrite_url <- url_suffix == "" || url_suffix == "latest"
   if (rewrite_url) {
+    rewritten_url <- sprintf(
+      "%s/cran/__linux__/$VERSION_CODENAME/latest",
+      user_host_prefix
+    )
     patched <- sub(
       "repos = c\\(CRAN = '[^']*'\\)",
-      sprintf("repos = c(CRAN = '%s')", ppm_codename_url),
+      sprintf("repos = c(CRAN = '%s')", rewritten_url),
       patched
     )
-    override_url <- ppm_codename_url
+    override_url <- rewritten_url
   } else {
     override_url <- user_url
   }

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -224,6 +224,7 @@ dock_from_renv <- function(
       repos_as_character
     )
   )
+  .patch_rprofile_for_ppm(dock, repos)
 
 
   if (!is.null(renv_version)){
@@ -242,5 +243,91 @@ dock_from_renv <- function(
   dock$COPY(basename(lockfile), "renv.lock")
   dock$RUN("--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv R -e 'renv::restore()'")
   dock
+}
+
+
+#' Patch the Rprofile.site line so PPM serves Linux binaries.
+#'
+#' Modifications applied conditionally to the `RUN ... tee Rprofile.site`
+#' line previously written by `dock_from_renv()`:
+#'  1. CRAN URL rewritten to the `__linux__/$VERSION_CODENAME/` PPM variant
+#'     (codename resolved from /etc/os-release at image build time). Skipped
+#'     if the user already pinned `__linux__/<codename>/` themselves.
+#'  2. `HTTPUserAgent` added in the strict format required by PPM
+#'     (`R (<version> <platform> <arch> <os>)`). Without it, PPM falls back
+#'     to source even with a `__linux__/` URL.
+#'  3. `renv.config.repos.override` set to the same PPM URL, so that
+#'     `renv::restore()` uses PPM instead of the repo URL recorded in the
+#'     lockfile (renv prefers lockfile repos by default; without this
+#'     override, fixes 1 and 2 are bypassed during `restore()`).
+#'  4. The `RUN` is prefixed with `. /etc/os-release && ` so that
+#'     `$VERSION_CODENAME` is defined when the shell evaluates the line.
+#'
+#' Only applies when at least one URL in `repos` looks like PPM.
+#' @noRd
+.patch_rprofile_for_ppm <- function(dock, repos) {
+  if (!any(grepl("packagemanager\\.(posit|rstudio)\\.(co|com)", repos))) {
+    return(invisible(NULL))
+  }
+  rps_idx <- grep("tee /usr/local/lib/R/etc/Rprofile\\.site", dock$Dockerfile)
+  if (length(rps_idx) != 1L) return(invisible(NULL))
+
+  patched <- dock$Dockerfile[rps_idx]
+
+  ppm_url <- "https://packagemanager.posit.co/cran/__linux__/$VERSION_CODENAME/latest"
+
+  # Don't rewrite if the user already pinned a Linux codename in the URL.
+  if (!grepl("__linux__/", patched)) {
+    patched <- sub(
+      "repos = c\\(CRAN = '[^']*'\\)",
+      sprintf("repos = c(CRAN = '%s')", ppm_url),
+      patched
+    )
+  }
+
+  # Force renv::restore() to use the configured PPM URL instead of the repos
+  # recorded in the lockfile (cf. ?renv::config -- option declared as
+  # "primarily useful for deployment / continuous integration"). Without this,
+  # the URL rewrite above is bypassed during restore().
+  if (!grepl("renv\\.config\\.repos\\.override", patched)) {
+    # Reuse whatever URL ended up on the `repos = c(CRAN = '...')` line so the
+    # override matches even when the user supplied their own PPM URL.
+    cran_url <- sub(
+      ".*repos = c\\(CRAN = '([^']*)'\\).*", "\\1",
+      patched
+    )
+    repos_override <- sprintf(
+      ", renv.config.repos.override = c(CRAN = '%s')",
+      cran_url
+    )
+    patched <- sub(
+      "(renv\\.config\\.pak\\.enabled = (TRUE|FALSE))",
+      paste0("\\1", repos_override),
+      patched
+    )
+  }
+
+  # The quadruple backslashes produce a literal `\$` in the Dockerfile RUN,
+  # so the shell does not expand $platform / $arch / $os and R sees them as
+  # R.Version()$platform when sourcing Rprofile.site.
+  user_agent <- paste0(
+    ", HTTPUserAgent = sprintf('R (%s %s %s %s)',",
+    " getRversion(),",
+    " R.Version()\\\\$platform, R.Version()\\\\$arch, R.Version()\\\\$os)"
+  )
+  if (!grepl("HTTPUserAgent", patched)) {
+    patched <- sub(
+      "(, Ncpus = [0-9]+)\\)",
+      paste0("\\1", user_agent, ")"),
+      patched
+    )
+  }
+
+  if (!grepl("/etc/os-release", patched)) {
+    patched <- sub("^RUN ", "RUN . /etc/os-release && ", patched)
+  }
+
+  dock$Dockerfile[rps_idx] <- patched
+  invisible(NULL)
 }
 

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -211,6 +211,12 @@ test_that("dock_from_renv injects PPM HTTPUserAgent, codename and renv override 
   expect_match(df, "HTTPUserAgent = sprintf\\('R \\(")
   expect_match(df, "\\. /etc/os-release && ")
   expect_match(df, "renv\\.config\\.repos\\.override = c\\(CRAN = '")
+  # Lock the UA escape level: the Dockerfile must contain literal
+  # `R.Version()\$platform` so bash's `echo "..."` emits a `$` (which R
+  # then evaluates correctly in Rprofile.site).
+  expect_match(df, "R.Version()\\$platform", fixed = TRUE)
+  expect_match(df, "R.Version()\\$arch", fixed = TRUE)
+  expect_match(df, "R.Version()\\$os", fixed = TRUE)
 })
 
 test_that("dock_from_renv leaves non-PPM repos untouched", {
@@ -310,6 +316,39 @@ test_that(".patch_rprofile_for_ppm is idempotent", {
     repos = c(CRAN = "https://packagemanager.posit.co/cran/latest")
   )
   expect_identical(out$Dockerfile, before)
+})
+
+test_that("dock_from_renv handles a trailing slash on cran/latest/", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest/"),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  # Trailing slash must not block the codename rewrite.
+  expect_match(df, "__linux__/\\$VERSION_CODENAME/")
+  expect_match(df, "HTTPUserAgent = sprintf")
+})
+
+test_that("dock_from_renv preserves the user's PPM host on rewrite", {
+  skip_if(is_rdevel, "skip on R-devel")
+  # rstudio.com (the legacy alias) must not be silently rewritten to
+  # posit.co; the user's scheme + host is preserved.
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://packagemanager.rstudio.com/cran/latest"),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(
+    df,
+    "packagemanager.rstudio.com/cran/__linux__/$VERSION_CODENAME/latest",
+    fixed = TRUE
+  )
+  expect_false(grepl("packagemanager.posit.co", df, fixed = TRUE))
 })
 
 unlink(dir_build, recursive = TRUE)

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -240,6 +240,76 @@ test_that("dock_from_renv preserves user-pinned PPM codename", {
   expect_match(df, "__linux__/jammy/", fixed = TRUE)
   expect_false(any(grepl("\\$VERSION_CODENAME", out$Dockerfile)))
   expect_match(df, "HTTPUserAgent = sprintf")
+  # The override must reference the user-pinned URL, not the codename URL.
+  expect_match(
+    df,
+    "renv.config.repos.override = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest')",
+    fixed = TRUE
+  )
+})
+
+test_that("dock_from_renv preserves a PPM snapshot-date URL", {
+  skip_if(is_rdevel, "skip on R-devel")
+  snapshot_url <- "https://packagemanager.posit.co/cran/2024-01-15"
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = snapshot_url),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  # The snapshot date must survive (no clobbering to /latest).
+  expect_match(df, "cran/2024-01-15", fixed = TRUE)
+  expect_false(any(grepl("\\$VERSION_CODENAME", out$Dockerfile)))
+  expect_false(any(grepl("/etc/os-release", out$Dockerfile)))
+  # The override must reference the user URL, not the codename URL.
+  expect_match(
+    df,
+    sprintf(
+      "renv.config.repos.override = c(CRAN = '%s')",
+      snapshot_url
+    ),
+    fixed = TRUE
+  )
+  # User-Agent is still useful with PPM regardless of URL form.
+  expect_match(df, "HTTPUserAgent = sprintf")
+})
+
+test_that("dock_from_renv leaves multi-entry repos vectors untouched", {
+  skip_if(is_rdevel, "skip on R-devel")
+  # The PPM patch is intentionally limited to a single CRAN-keyed PPM URL;
+  # multi-entry vectors fall through unmodified (back-compat / no surprises).
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(
+      RSPM = "https://packagemanager.posit.co/cran/latest",
+      CRAN = "https://cran.rstudio.com/"
+    ),
+    renv_version = "0.0.0"
+  )
+  expect_false(any(grepl("__linux__", out$Dockerfile)))
+  expect_false(any(grepl("HTTPUserAgent", out$Dockerfile)))
+  expect_false(any(grepl("/etc/os-release", out$Dockerfile)))
+  expect_false(any(grepl("renv\\.config\\.repos\\.override", out$Dockerfile)))
+})
+
+test_that(".patch_rprofile_for_ppm is idempotent", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest"),
+    renv_version = "0.0.0"
+  )
+  before <- out$Dockerfile
+  # Re-applying the helper must be a no-op: each mutation is gated by
+  # the absence of its target token.
+  dockerfiler:::.patch_rprofile_for_ppm(
+    out,
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest")
+  )
+  expect_identical(out$Dockerfile, before)
 })
 
 unlink(dir_build, recursive = TRUE)

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -198,5 +198,49 @@ socle_install_version <- "remotes::install_version\\(\"renv\", version = \""
 
 })
 
+test_that("dock_from_renv injects PPM HTTPUserAgent, codename and renv override when repos is PPM", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest"),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "__linux__/\\$VERSION_CODENAME/")
+  expect_match(df, "HTTPUserAgent = sprintf\\('R \\(")
+  expect_match(df, "\\. /etc/os-release && ")
+  expect_match(df, "renv\\.config\\.repos\\.override = c\\(CRAN = '")
+})
+
+test_that("dock_from_renv leaves non-PPM repos untouched", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://cran.rstudio.com/"),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_false(any(grepl("__linux__", out$Dockerfile)))
+  expect_false(any(grepl("HTTPUserAgent", out$Dockerfile)))
+  expect_false(any(grepl("/etc/os-release", out$Dockerfile)))
+  expect_false(any(grepl("renv\\.config\\.repos\\.override", out$Dockerfile)))
+})
+
+test_that("dock_from_renv preserves user-pinned PPM codename", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"),
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "__linux__/jammy/", fixed = TRUE)
+  expect_false(any(grepl("\\$VERSION_CODENAME", out$Dockerfile)))
+  expect_match(df, "HTTPUserAgent = sprintf")
+})
+
 unlink(dir_build, recursive = TRUE)
 


### PR DESCRIPTION
## Summary

When `dock_from_renv()` is given a `repos` argument that points to Posit Package Manager (PPM), the generated Dockerfile currently still pulls every package as **source** and recompiles every C/C++ package at image build time. Three things must be true for PPM to serve Linux binaries, and none of them are true today:

1. **The URL must contain `__linux__/<codename>/`.** PPM only routes to the per-distro binary index when the codename is in the URL path. Codenames are read from `/etc/os-release` at build time (`$VERSION_CODENAME`).
2. **The `User-Agent` must match `R (<version> <platform> <arch> <os>)` exactly.** PPM matches the UA via a strict regex; any prefix (e.g. `R/<v> R (...)`) silently falls back to source. Verified empirically with `curl`:

   | UA | URL | Body |
   |---|---|---|
   | `R/4.5.0 R (4.5.0) x86_64-pc-linux-gnu x86_64 linux-gnu` | `__linux__/noble/latest/src/contrib/rpart_4.1.27.tar.gz` | `src/*.c` (source, 624 KB) |
   | `R (4.5.0 x86_64-pc-linux-gnu x86_64 linux-gnu)`         | same URL                                                  | `libs/rpart.so` (binary, 696 KB) |

3. **`renv::restore()` must use the `options('repos')` URL, not the lockfile's.** By default renv prefers the repo URL recorded in `renv.lock` (typically `cran.rstudio.com`) for reproducibility — bypassing fixes 1 and 2 entirely. `?renv::config` documents `renv.config.repos.override` as "primarily useful for deployment / continuous integration", which is exactly our case.

This PR adds an internal helper `.patch_rprofile_for_ppm()` that post-patches the existing `RUN ... tee Rprofile.site` line when `repos` is a single CRAN-keyed PPM URL. Four conditional mutations:

- rewrite the URL to `https://packagemanager.posit.co/cran/__linux__/\$VERSION_CODENAME/latest` when (and only when) the input is the bare `cran` or `cran/latest` form;
- inject `renv.config.repos.override = c(CRAN = '<url>')` so `restore()` uses PPM;
- inject `HTTPUserAgent = sprintf('R (%s %s %s %s)', getRversion(), R.Version()\$platform, R.Version()\$arch, R.Version()\$os)`;
- prefix the `RUN` with `. /etc/os-release && ` when `\$VERSION_CODENAME` ends up in the line.

## Scope and known limitations

- Only fires when `repos` is a single-entry vector named `CRAN`. Multi-entry vectors (e.g. `c(RSPM = '<PPM>', CRAN = '<cran>')`) are intentionally not transformed — rebuilding a multi-key block robustly is out of scope.
- User-pinned codenames (`__linux__/jammy/`) and snapshot-date URLs (`cran/2024-01-15`) are preserved as-is; only the bare `cran` / `cran/latest` form gets the codename injection.
- Hardcodes `latest` in the rewritten URL; users wanting a snapshot date can pass it directly and it will be preserved.

Strictly backward-compatible: any non-PPM `repos` value, multi-entry vector, or non-`CRAN` key short-circuits the helper and the generated Dockerfile is byte-identical to before this PR.

## Test plan

- [x] `dock_from_renv injects PPM HTTPUserAgent, codename and renv override when repos is PPM` — happy path, asserts all four markers.
- [x] `dock_from_renv leaves non-PPM repos untouched` — back-compat sanity check.
- [x] `dock_from_renv preserves user-pinned PPM codename` — `__linux__/jammy/` survives, override URL matches.
- [x] `dock_from_renv preserves a PPM snapshot-date URL` — `cran/2024-01-15` survives, no codename injection, no `/etc/os-release` prefix, override URL matches.
- [x] `dock_from_renv leaves multi-entry repos vectors untouched` — `c(RSPM=..., CRAN=...)` is a no-op.
- [x] `.patch_rprofile_for_ppm is idempotent` — re-applying the helper is a no-op.
- [x] `devtools::test(filter = "dock_from_renv")` -> 38 PASS / 0 FAIL.
- [x] `R CMD check` clean (only environmental qpdf warning + clock NOTE on the build sandbox).