### PR TITLE
Regenerate README for 0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/ThinkR-open/dockerfiler/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/dockerfiler/actions)
@@ -19,7 +18,7 @@ You’re reading the doc about version :
 
 ``` r
 desc::desc_get_version()
-#> [1] '0.2.5'
+#> [1] '0.2.6'
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary

After PRs #88 and #89 were merged, `DESCRIPTION` is at `0.2.6` but `README.md` still renders `desc::desc_get_version()` as `'0.2.5'` (the chunk was last knit when the version was 0.2.5).

This PR runs `devtools::build_readme()` against the current `DESCRIPTION`. The only meaningful change is `'0.2.5'` -> `'0.2.6'` in the rendered code chunk; one stray blank line near the top is also removed by the renderer.

## Test plan

- [x] `devtools::build_readme()` ran cleanly.
- [x] `git diff README.md` shows only the version string + one whitespace tweak; no other content drift.