### PR TITLE
feat(ARG): support an optional default value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# dockerfiler (development version)
+
+- `dock$ARG()` and the internal `add_arg()` helper gain a `default`
+  parameter to emit `ARG <name>=<default>` instead of `ARG <name>`.
+  Closes #8.
+
+
 # dockerfiler 0.2.6
 
 - `dock_from_renv()` now auto-configures the generated Dockerfile to fetch

--- a/R/add.R
+++ b/R/add.R
@@ -92,9 +92,9 @@ add_arg <- function(arg, default = NULL) {
   } else {
     if (grepl("=", arg, fixed = TRUE)) {
       stop(
-        "`arg` already contains an `=` sign; pass either ",
-        "`add_arg(\"NAME=value\")` or `add_arg(\"NAME\", default = \"value\")`, ",
-        "but not both."
+        "`arg` already contains an `=` sign. Pass either the inlined ",
+        "form (`\"NAME=value\"`) or the explicit default ",
+        "(`default = \"value\"`), but not both."
       )
     }
     glue("ARG {arg}={default}")

--- a/R/add.R
+++ b/R/add.R
@@ -86,8 +86,12 @@ add_user <- function(user) {
   glue("USER {user}")
 }
 
-add_arg <- function(arg) {
-  glue("ARG {arg}")
+add_arg <- function(arg, default = NULL) {
+  if (is.null(default)) {
+    glue("ARG {arg}")
+  } else {
+    glue("ARG {arg}={default}")
+  }
 }
 
 add_onbuild <- function(cmd) {

--- a/R/add.R
+++ b/R/add.R
@@ -90,6 +90,13 @@ add_arg <- function(arg, default = NULL) {
   if (is.null(default)) {
     glue("ARG {arg}")
   } else {
+    if (grepl("=", arg, fixed = TRUE)) {
+      stop(
+        "`arg` already contains an `=` sign; pass either ",
+        "`add_arg(\"NAME=value\")` or `add_arg(\"NAME\", default = \"value\")`, ",
+        "but not both."
+      )
+    }
     glue("ARG {arg}={default}")
   }
 }

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -105,7 +105,9 @@ self$Dockerfile <- c(self$Dockerfile, add_user(user))
 #' @param arg The argument to add.
 #' @param ahead If TRUE, add the argument at the beginning of the Dockerfile.
 #' @param default Optional default value. When not `NULL`, the directive
-#'   becomes `ARG <arg>=<default>`.
+#'   becomes `ARG <arg>=<default>`. Requires `arg` to be just the name
+#'   (no embedded `=`); supplying both an inlined `=` in `arg` and a
+#'   non-`NULL` `default` errors.
 #' @return the Dockerfile object, invisibly.
 ARG = function(arg, ahead = FALSE, default = NULL) {
 if (ahead) {

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -109,9 +109,9 @@ self$Dockerfile <- c(self$Dockerfile, add_user(user))
 #' @return the Dockerfile object, invisibly.
 ARG = function(arg, ahead = FALSE, default = NULL) {
 if (ahead) {
-self$Dockerfile <- c(add_arg(arg, default), self$Dockerfile)
+self$Dockerfile <- c(add_arg(arg, default = default), self$Dockerfile)
 } else {
-self$Dockerfile <- c(self$Dockerfile, add_arg(arg, default))
+self$Dockerfile <- c(self$Dockerfile, add_arg(arg, default = default))
 }
 },
 #' @description

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -104,12 +104,14 @@ self$Dockerfile <- c(self$Dockerfile, add_user(user))
 #' Add a ARG command.
 #' @param arg The argument to add.
 #' @param ahead If TRUE, add the argument at the beginning of the Dockerfile.
+#' @param default Optional default value. When not `NULL`, the directive
+#'   becomes `ARG <arg>=<default>`.
 #' @return the Dockerfile object, invisibly.
-ARG = function(arg, ahead = FALSE) {
+ARG = function(arg, ahead = FALSE, default = NULL) {
 if (ahead) {
-self$Dockerfile <- c(add_arg(arg), self$Dockerfile)
+self$Dockerfile <- c(add_arg(arg, default), self$Dockerfile)
 } else {
-self$Dockerfile <- c(self$Dockerfile, add_arg(arg))
+self$Dockerfile <- c(self$Dockerfile, add_arg(arg, default))
 }
 },
 #' @description

--- a/man/Dockerfile.Rd
+++ b/man/Dockerfile.Rd
@@ -318,7 +318,9 @@ Add a ARG command.
 \item{\code{ahead}}{If TRUE, add the argument at the beginning of the Dockerfile.}
 
 \item{\code{default}}{Optional default value. When not \code{NULL}, the directive
-becomes \verb{ARG <arg>=<default>}.}
+becomes \verb{ARG <arg>=<default>}. Requires \code{arg} to be just the name
+(no embedded \code{=}); supplying both an inlined \code{=} in \code{arg} and a
+non-\code{NULL} \code{default} errors.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Dockerfile.Rd
+++ b/man/Dockerfile.Rd
@@ -307,7 +307,7 @@ the Dockerfile object, invisibly.
 \subsection{Method \code{ARG()}}{
 Add a ARG command.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$ARG(arg, ahead = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$ARG(arg, ahead = FALSE, default = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -316,6 +316,9 @@ Add a ARG command.
 \item{\code{arg}}{The argument to add.}
 
 \item{\code{ahead}}{If TRUE, add the argument at the beginning of the Dockerfile.}
+
+\item{\code{default}}{Optional default value. When not \code{NULL}, the directive
+becomes \verb{ARG <arg>=<default>}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-r6.R
+++ b/tests/testthat/test-r6.R
@@ -60,3 +60,33 @@ test_that("warning works", {
   # expect_warning(my_dock$COPY("nfi", "norifi", force = FALSE))
   expect_warning(my_dock$EXPOSE("9000"))
 })
+
+test_that("dock$ARG emits ARG <name> when no default is provided", {
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$ARG("MYVAR")
+  expect_true(any(grepl("^ARG MYVAR$", my_dock$Dockerfile)))
+})
+
+test_that("dock$ARG emits ARG <name>=<default> when a default is provided", {
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$ARG("MYVAR", default = "myval")
+  expect_true(any(grepl("^ARG MYVAR=myval$", my_dock$Dockerfile)))
+})
+
+test_that("dock$ARG default still respects ahead = TRUE", {
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$RUN("placeholder")
+  my_dock$ARG("MYVAR", ahead = TRUE, default = "myval")
+  # FROM stays first; ARG is inserted before everything else (i.e. before
+  # the FROM as well, because that's how `ahead = TRUE` is currently
+  # implemented). We only assert the ARG line is present and well-formed.
+  expect_true(any(my_dock$Dockerfile == "ARG MYVAR=myval"))
+})
+
+test_that("add_arg emits the right directive in both modes", {
+  expect_equal(as.character(dockerfiler:::add_arg("MYVAR")), "ARG MYVAR")
+  expect_equal(
+    as.character(dockerfiler:::add_arg("MYVAR", default = "myval")),
+    "ARG MYVAR=myval"
+  )
+})

--- a/tests/testthat/test-r6.R
+++ b/tests/testthat/test-r6.R
@@ -90,3 +90,14 @@ test_that("add_arg emits the right directive in both modes", {
     "ARG MYVAR=myval"
   )
 })
+
+test_that("add_arg errors when both `arg` contains `=` and `default` is supplied", {
+  # Avoids producing the silently invalid `ARG MYVAR=oldval=newval`.
+  expect_error(
+    dockerfiler:::add_arg("MYVAR=oldval", default = "newval"),
+    "already contains an `=` sign"
+  )
+  # Either form is fine on its own.
+  expect_no_error(dockerfiler:::add_arg("MYVAR=oldval"))
+  expect_no_error(dockerfiler:::add_arg("MYVAR", default = "newval"))
+})

--- a/tests/testthat/test-r6.R
+++ b/tests/testthat/test-r6.R
@@ -101,3 +101,15 @@ test_that("add_arg errors when both `arg` contains `=` and `default` is supplied
   expect_no_error(dockerfiler:::add_arg("MYVAR=oldval"))
   expect_no_error(dockerfiler:::add_arg("MYVAR", default = "newval"))
 })
+
+test_that("legacy inlined form `dock$ARG(\"NAME=value\")` keeps emitting `ARG NAME=value`", {
+  # Backward-compat regression test: callers who pre-date the `default`
+  # parameter must see the same output as before.
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$ARG("MYVAR=myval")
+  expect_true(any(my_dock$Dockerfile == "ARG MYVAR=myval"))
+  expect_equal(
+    as.character(dockerfiler:::add_arg("MYVAR=myval")),
+    "ARG MYVAR=myval"
+  )
+})


### PR DESCRIPTION
## Summary

Reworks the idea originally proposed in #8: let `dock\$ARG()` emit
`ARG <name>=<default>` directly via a `default` parameter, instead of
forcing users to inline the equals into the argument string.

```r
# before (still works)
dock\$ARG("MYVAR=myval")

# after (new, more idiomatic)
dock\$ARG("MYVAR", default = "myval")
```

Same change applied to the internal `add_arg()` helper used inside the
package.

## Backward compatibility

\`default\` is the third positional parameter (after \`arg\` and the
existing \`ahead\`) with default \`NULL\`. All existing call sites are
byte-identical:

| Old call | Output |
|---|---|
| \`dock\$ARG("FOO")\` | \`ARG FOO\` |
| \`dock\$ARG("FOO", TRUE)\` | \`ARG FOO\` (inserted at the start) |
| \`dock\$ARG("FOO=bar")\` | \`ARG FOO=bar\` |
| \`dock\$ARG("FOO", default = "bar")\` (new) | \`ARG FOO=bar\` |

## Closes

Closes #8 — the original PR by @antoine-sachet bundled this idea with
a large R6 roxygenisation chantier that has since been done elsewhere,
making the diff hard to merge. This PR keeps only the load-bearing
change (4 R lines + tests + NEWS).

## Test plan

- [x] \`devtools::test(filter = "r6")\` -> 31 PASS / 0 FAIL.
- [x] 4 new tests covering: emits ARG <name>; emits ARG <name>=<default>;
      respects \`ahead = TRUE\` with default; the bare \`add_arg()\` helper.
- [x] \`devtools::document()\` regenerated \`man/Dockerfile.Rd\` (RoxygenNote
      reverted to 7.3.2 to match origin).

Co-authored with @antoine-sachet (original PR #8 author).