### PR TITLE
feat(dock_from_renv): expose renv_paths_cache parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@
   via `--build-arg GITHUB_PAT=$GITHUB_PAT`), or `"secret"` to use
   BuildKit secret mounts (the PAT is never persisted in image
   metadata; recommended for published images). Closes #18.
+- `dock_from_renv()` gains a `renv_paths_cache` parameter (default
+  `/root/.cache/R/renv`) used as the build-arg default, the propagated
+  `ENV` value and the cache mount target. Users can override the renv
+  cache location at image build time with
+  `--build-arg RENV_PATHS_CACHE=...` without regenerating the
+  Dockerfile.
 
 
 # dockerfiler 0.2.6

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -41,6 +41,11 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   mount on the `renv::restore()` RUN; the PAT is never persisted in
 #'   the image; requires BuildKit, so pass with
 #'   `DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...`).
+#' @param renv_paths_cache character. Path used as the default of the
+#'   `RENV_PATHS_CACHE` build-arg, propagated as an `ENV` variable, and
+#'   used as the cache mount target for `renv::restore()`. Lets users
+#'   override the renv cache location at image build time via
+#'   `--build-arg RENV_PATHS_CACHE=...`.
 #' @importFrom utils getFromNamespace
 #' @return A R6 object of class `Dockerfile`.
 #' @details
@@ -79,7 +84,8 @@ dock_from_renv <- function(
   dependencies = NA,
   sysreqs_platform = "ubuntu",
   renv_version,
-  github_pat = c("none", "build_arg", "secret")
+  github_pat = c("none", "build_arg", "secret"),
+  renv_paths_cache = "/root/.cache/R/renv"
 ) {
   github_pat <- match.arg(github_pat)
   try(dockerfiler::renv$initialize(),silent=TRUE)
@@ -96,6 +102,8 @@ dock_from_renv <- function(
     AS = AS
   )
   .github_pat_setup(dock, github_pat)
+  dock$ARG(sprintf("RENV_PATHS_CACHE=%s", renv_paths_cache))
+  dock$ENV(key = "RENV_PATHS_CACHE", value = "${RENV_PATHS_CACHE}")
   if (!is.null(user)) {
     dock$USER(user)
   }
@@ -257,7 +265,7 @@ dock_from_renv <- function(
   dock$COPY(basename(lockfile), "renv.lock")
   dock$RUN(
     paste0(
-      "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv ",
+      "--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} ",
       .github_pat_run_prefix(github_pat),
       "R -e 'renv::restore()'"
     )

--- a/man/dock_from_renv.Rd
+++ b/man/dock_from_renv.Rd
@@ -18,7 +18,8 @@ dock_from_renv(
   dependencies = NA,
   sysreqs_platform = "ubuntu",
   renv_version,
-  github_pat = c("none", "build_arg", "secret")
+  github_pat = c("none", "build_arg", "secret"),
+  renv_paths_cache = "/root/.cache/R/renv"
 )
 }
 \arguments{
@@ -72,6 +73,12 @@ visible in the image metadata), or \code{"secret"} (BuildKit secret
 mount on the \code{renv::restore()} RUN; the PAT is never persisted in
 the image; requires BuildKit, so pass with
 \verb{DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
+
+\item{renv_paths_cache}{character. Path used as the default of the
+\code{RENV_PATHS_CACHE} build-arg, propagated as an \code{ENV} variable, and
+used as the cache mount target for \code{renv::restore()}. Lets users
+override the renv cache location at image build time via
+\verb{--build-arg RENV_PATHS_CACHE=...}.}
 }
 \value{
 A R6 object of class \code{Dockerfile}.

--- a/tests/testthat/renv_Dockerfile
+++ b/tests/testthat/renv_Dockerfile
@@ -1,8 +1,10 @@
 FROM rocker/verse:4.1.2
+ARG RENV_PATHS_CACHE=/root/.cache/R/renv
+ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"
 RUN fake sys reqs
 RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/
 RUN echo "options(renv.config.pak.enabled = FALSE, repos = fake repos, download.file.method = 'libcurl', Ncpus = 4)" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site
 RUN R -e 'install.packages("remotes")'
 RUN R -e 'remotes::install_version("renv", version = "0.0.0")'
 COPY renv.lock renv.lock
-RUN --mount=type=cache,id=renv-cache,target=/root/.cache/R/renv R -e 'renv::restore()'
+RUN --mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} R -e 'renv::restore()'

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -401,11 +401,53 @@ test_that("dock_from_renv emits a secret mount on restore() when github_pat = 's
     fixed = TRUE
   )
   # The renv cache mount must coexist with the secret mount on the same RUN.
+  # Cache target uses ${RENV_PATHS_CACHE} since renv_paths_cache landed.
   expect_match(
     df,
-    "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv --mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat) R -e 'renv::restore()'",
+    "--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} --mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat) R -e 'renv::restore()'",
     fixed = TRUE
   )
+})
+
+test_that("dock_from_renv emits the RENV_PATHS_CACHE build-arg by default", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "ARG RENV_PATHS_CACHE=/root/.cache/R/renv", fixed = TRUE)
+  expect_match(df, 'ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"', fixed = TRUE)
+  expect_match(
+    df,
+    "--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE}",
+    fixed = TRUE
+  )
+})
+
+test_that("dock_from_renv honors a custom renv_paths_cache path", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_paths_cache = "/srv/renv-cache",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  # Only the build-arg default changes -- the ENV value and the mount
+  # target keep referencing the variable, so users overriding the path
+  # at `docker build --build-arg RENV_PATHS_CACHE=...` still take effect
+  # even if they don't change the dockerfile generation defaults.
+  expect_match(df, "ARG RENV_PATHS_CACHE=/srv/renv-cache", fixed = TRUE)
+  expect_match(df, 'ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"', fixed = TRUE)
+  expect_match(
+    df,
+    "--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE}",
+    fixed = TRUE
+  )
+  # The hard-coded /root/.cache/R/renv path must NOT remain in the file.
+  expect_false(grepl("target=/root/.cache/R/renv", df, fixed = TRUE))
 })
 
 unlink(dir_build, recursive = TRUE)


### PR DESCRIPTION
## Summary

Reworks the idea originally proposed in #87 as a proper public-API
parameter rather than hardcoded values.

`dock_from_renv()` gains a `renv_paths_cache` parameter (default
`/root/.cache/R/renv`) that drives three sites in the generated
Dockerfile:

- `ARG RENV_PATHS_CACHE=<default>` build-arg directive
- `ENV "RENV_PATHS_CACHE"="\${RENV_PATHS_CACHE}"` propagation
- `--mount=type=cache,id=renv-cache,target=\${RENV_PATHS_CACHE}` mount
  target on the final `renv::restore()` RUN

This means users can override the renv cache location at image build
time without regenerating the Dockerfile:

```sh
docker build --build-arg RENV_PATHS_CACHE=/srv/renv-cache -t app .
```

The previous behaviour (cache rooted at `/root/.cache/R/renv`) is
preserved as the default, so it is strictly backward-compatible.

## Closes

Closes #87 — the original PR was a year old, hardcoded the cache path
in three places, and downgraded the package version to `0.2.5.9001`.
This rework keeps only the load-bearing change and exposes it
properly through the public API.

## Test plan

- [x] `devtools::test(filter = "dock_from_renv")` -> 54 PASS / 0 FAIL.
- [x] 2 new tests:
  - default `renv_paths_cache` -> ARG/ENV/mount all reference the variable;
  - custom `renv_paths_cache = "/srv/renv-cache"` -> only the build-arg
    default changes; ENV and mount keep referencing the variable so
    runtime override via `--build-arg` still works.
- [x] Existing fixture `tests/testthat/renv_Dockerfile` updated.
- [x] `devtools::document()` regenerated `man/dock_from_renv.Rd`
      (RoxygenNote reverted to 7.3.2 to match origin).

Co-authored with @VincentGuyader (original PR #87 author).