### PR TITLE
feat: opt-in GitHub PAT support (build-arg or BuildKit secret)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,14 @@
 - `dock$ARG()` and the internal `add_arg()` helper gain a `default`
   parameter to emit `ARG <name>=<default>` instead of `ARG <name>`.
   Closes #8.
+- `dock_from_desc()` and `dock_from_renv()` gain a `github_pat`
+  parameter (default `"none"`) controlling how a GitHub PAT is provided
+  to `remotes::install_github()` / `remotes::install_local()` /
+  `renv::restore()` for private dependency repositories. Set to
+  `"build_arg"` to emit `ARG GITHUB_PAT` + `ENV` propagation (passed
+  via `--build-arg GITHUB_PAT=$GITHUB_PAT`), or `"secret"` to use
+  BuildKit secret mounts (the PAT is never persisted in image
+  metadata; recommended for published images). Closes #18.
 
 
 # dockerfiler 0.2.6

--- a/R/dock_from_desc.R
+++ b/R/dock_from_desc.R
@@ -53,6 +53,15 @@ quote_not_na <- function(x){
 #'     an updated tar.gz is created.
 #' @param extra_sysreqs character vector. Extra debian system requirements.
 #'    Will be installed with apt-get install.
+#' @param github_pat character. How to provide a GitHub PAT to
+#'   `remotes::install_github()` for private dependency repositories.
+#'   One of `"none"` (default; the generated Dockerfile does not
+#'   reference any PAT), `"build_arg"` (emit `ARG GITHUB_PAT` + `ENV`
+#'   propagation; pass with `--build-arg GITHUB_PAT=$GITHUB_PAT`; the
+#'   PAT will be visible in the image metadata), or `"secret"`
+#'   (BuildKit secret mount on each `install_github()` / `install_local()`
+#'   RUN; the PAT is never persisted in the image; pass with
+#'   `docker build --secret id=github_pat,env=GITHUB_PAT ...`).
 #'
 #' @export
 #' @rdname dockerfiles
@@ -78,8 +87,10 @@ dock_from_desc <- function(
   expand = FALSE,
   update_tar_gz = TRUE,
   build_from_source = TRUE,
-  extra_sysreqs = NULL
+  extra_sysreqs = NULL,
+  github_pat = c("none", "build_arg", "secret")
 ) {
+  github_pat <- match.arg(github_pat)
   path <- fs::path_abs(path)
 
   packages <- desc_get_deps(path)$package
@@ -158,6 +169,7 @@ dock_from_desc <- function(
     FROM = FROM,
     AS = AS
   )
+  .github_pat_setup(dock, github_pat)
 
   if (length(system_requirement) > 0) {
     if (!expand) {
@@ -233,7 +245,8 @@ dock_from_desc <- function(
       function(dock, ver, nm) {
         res <- dock$RUN(
           sprintf(
-            "Rscript -e 'remotes::install_github(\"%s\")'",
+            "%sRscript -e 'remotes::install_github(\"%s\")'",
+            .github_pat_run_prefix(github_pat),
             ver
           )
         )
@@ -300,13 +313,23 @@ dock_from_desc <- function(
       from = paste0(read.dcf(path)[1], "_*.tar.gz"),
       to = "/app.tar.gz"
     )
-    dock$RUN("R -e 'remotes::install_local(\"/app.tar.gz\",upgrade=\"never\")'")
+    dock$RUN(
+      paste0(
+        .github_pat_run_prefix(github_pat),
+        "R -e 'remotes::install_local(\"/app.tar.gz\",upgrade=\"never\")'"
+      )
+    )
     dock$RUN("rm /app.tar.gz")
   } else {
     dock$RUN("mkdir /build_zone")
     dock$ADD(from = ".", to = "/build_zone")
     dock$WORKDIR("/build_zone")
-    dock$RUN("R -e 'remotes::install_local(upgrade=\"never\")'")
+    dock$RUN(
+      paste0(
+        .github_pat_run_prefix(github_pat),
+        "R -e 'remotes::install_local(upgrade=\"never\")'"
+      )
+    )
     dock$RUN("rm -rf /build_zone")
   }
   # Add a dockerignore
@@ -314,6 +337,7 @@ dock_from_desc <- function(
     path = dirname(path)
   )
 
+  .github_pat_announce(github_pat)
   dock
 }
 

--- a/R/dock_from_desc.R
+++ b/R/dock_from_desc.R
@@ -60,8 +60,9 @@ quote_not_na <- function(x){
 #'   propagation; pass with `--build-arg GITHUB_PAT=$GITHUB_PAT`; the
 #'   PAT will be visible in the image metadata), or `"secret"`
 #'   (BuildKit secret mount on each `install_github()` / `install_local()`
-#'   RUN; the PAT is never persisted in the image; pass with
-#'   `docker build --secret id=github_pat,env=GITHUB_PAT ...`).
+#'   RUN; the PAT is never persisted in the image; requires BuildKit, so
+#'   pass with
+#'   `DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...`).
 #'
 #' @export
 #' @rdname dockerfiles

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -32,6 +32,15 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   - `FALSE`: do not install any dependencies. (You might end up with a
 #'     non-working package, and/or the installation might fail.)
 #' @param sysreqs_platform System requirements platform.`ubuntu` by default. If `NULL`, then the  current platform is used. Can be : "ubuntu-22.04" if needed to fit with the `FROM` Operating System. Only debian or ubuntu based images are supported
+#' @param github_pat character. How to provide a GitHub PAT to
+#'   `renv::restore()` for private dependency repositories. One of
+#'   `"none"` (default; the generated Dockerfile does not reference
+#'   any PAT), `"build_arg"` (emit `ARG GITHUB_PAT` + `ENV` propagation;
+#'   pass with `--build-arg GITHUB_PAT=$GITHUB_PAT`; the PAT will be
+#'   visible in the image metadata), or `"secret"` (BuildKit secret
+#'   mount on the `renv::restore()` RUN; the PAT is never persisted in
+#'   the image; pass with
+#'   `docker build --secret id=github_pat,env=GITHUB_PAT ...`).
 #' @importFrom utils getFromNamespace
 #' @return A R6 object of class `Dockerfile`.
 #' @details
@@ -69,8 +78,10 @@ dock_from_renv <- function(
   user = NULL,
   dependencies = NA,
   sysreqs_platform = "ubuntu",
-  renv_version
+  renv_version,
+  github_pat = c("none", "build_arg", "secret")
 ) {
+  github_pat <- match.arg(github_pat)
   try(dockerfiler::renv$initialize(),silent=TRUE)
   lock <- dockerfiler::renv$lockfile_read(file = lockfile) # using vendored renv
   # https://rstudio.github.io/renv/reference/vendor.html?q=vendor#null
@@ -84,6 +95,7 @@ dock_from_renv <- function(
     ),
     AS = AS
   )
+  .github_pat_setup(dock, github_pat)
   if (!is.null(user)) {
     dock$USER(user)
   }
@@ -243,7 +255,14 @@ dock_from_renv <- function(
   }
 
   dock$COPY(basename(lockfile), "renv.lock")
-  dock$RUN("--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv R -e 'renv::restore()'")
+  dock$RUN(
+    paste0(
+      "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv ",
+      .github_pat_run_prefix(github_pat),
+      "R -e 'renv::restore()'"
+    )
+  )
+  .github_pat_announce(github_pat)
   dock
 }
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -39,8 +39,8 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   pass with `--build-arg GITHUB_PAT=$GITHUB_PAT`; the PAT will be
 #'   visible in the image metadata), or `"secret"` (BuildKit secret
 #'   mount on the `renv::restore()` RUN; the PAT is never persisted in
-#'   the image; pass with
-#'   `docker build --secret id=github_pat,env=GITHUB_PAT ...`).
+#'   the image; requires BuildKit, so pass with
+#'   `DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...`).
 #' @importFrom utils getFromNamespace
 #' @return A R6 object of class `Dockerfile`.
 #' @details

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,3 +32,55 @@ cat_info <- function(...) {
     bullet_col = "grey"
   )
 }
+
+#' Add GITHUB_PAT plumbing to a Dockerfile.
+#'
+#' For mode `"build_arg"`, emits an `ARG GITHUB_PAT` directive (no
+#' default) and an `ENV GITHUB_PAT=${GITHUB_PAT}` propagation so any
+#' subsequent RUN inherits the value. For `"none"` and `"secret"`, no
+#' top-level directive is emitted (in `"secret"` mode the secret is
+#' mounted RUN-by-RUN by [.github_pat_run_prefix()]).
+#' Side-effects only: modifies `dock` in place.
+#' @noRd
+.github_pat_setup <- function(dock, mode) {
+  if (identical(mode, "build_arg")) {
+    dock$ARG("GITHUB_PAT")
+    dock$ENV(key = "GITHUB_PAT", value = "${GITHUB_PAT}")
+  }
+  invisible(NULL)
+}
+
+#' BuildKit secret-mount prefix for a RUN that needs `GITHUB_PAT`.
+#'
+#' Returns a string to prepend to a RUN command body. Empty string for
+#' modes `"none"` and `"build_arg"` (the latter relies on the ENV set
+#' by [.github_pat_setup()]); the `--mount=type=secret,...,env=GITHUB_PAT`
+#' fragment for mode `"secret"`.
+#' @noRd
+.github_pat_run_prefix <- function(mode) {
+  if (identical(mode, "secret")) {
+    "--mount=type=secret,id=github_pat,env=GITHUB_PAT "
+  } else {
+    ""
+  }
+}
+
+#' Emit a one-shot reminder describing how the PAT must be supplied at
+#' `docker build` time. No-op when mode is `"none"`.
+#' @noRd
+.github_pat_announce <- function(mode) {
+  if (identical(mode, "build_arg")) {
+    cat_info(
+      "Pass the PAT at build time: ",
+      "`docker build --build-arg GITHUB_PAT=$GITHUB_PAT ...` ",
+      "(NB: the PAT will be visible in the resulting image metadata; ",
+      "use `github_pat = \"secret\"` for published images)."
+    )
+  } else if (identical(mode, "secret")) {
+    cat_info(
+      "Pass the PAT at build time: ",
+      "`DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...`"
+    )
+  }
+  invisible(NULL)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,12 +54,19 @@ cat_info <- function(...) {
 #'
 #' Returns a string to prepend to a RUN command body. Empty string for
 #' modes `"none"` and `"build_arg"` (the latter relies on the ENV set
-#' by [.github_pat_setup()]); the `--mount=type=secret,...,env=GITHUB_PAT`
-#' fragment for mode `"secret"`.
+#' by [.github_pat_setup()]); a `--mount=type=secret,...` fragment plus
+#' a shell `GITHUB_PAT=$(cat ...)` prefix for mode `"secret"`.
+#'
+#' The file-read pattern (`cat /run/secrets/github_pat`) is preferred
+#' over the `--mount=type=secret,...,env=GITHUB_PAT` shortcut because
+#' the latter requires Dockerfile frontend `1.6+` (introduced in 2023)
+#' and otherwise needs an explicit `# syntax=docker/dockerfile:1.6`
+#' header. The file-read pattern works on every BuildKit version that
+#' supports `--mount=type=secret` at all.
 #' @noRd
 .github_pat_run_prefix <- function(mode) {
   if (identical(mode, "secret")) {
-    "--mount=type=secret,id=github_pat,env=GITHUB_PAT "
+    "--mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat) "
   } else {
     ""
   }

--- a/man/dock_from_renv.Rd
+++ b/man/dock_from_renv.Rd
@@ -17,7 +17,8 @@ dock_from_renv(
   user = NULL,
   dependencies = NA,
   sysreqs_platform = "ubuntu",
-  renv_version
+  renv_version,
+  github_pat = c("none", "build_arg", "secret")
 )
 }
 \arguments{
@@ -61,6 +62,16 @@ If the \code{renv.lock} file does not specify a renv version,
 the version of renv bundled with dockerfiler,
 specifically 1.0.3, will be used.
 If you set it to \code{NULL}, the latest available version of renv will be used.}
+
+\item{github_pat}{character. How to provide a GitHub PAT to
+\code{renv::restore()} for private dependency repositories. One of
+\code{"none"} (default; the generated Dockerfile does not reference
+any PAT), \code{"build_arg"} (emit \verb{ARG GITHUB_PAT} + \code{ENV} propagation;
+pass with \verb{--build-arg GITHUB_PAT=$GITHUB_PAT}; the PAT will be
+visible in the image metadata), or \code{"secret"} (BuildKit secret
+mount on the \code{renv::restore()} RUN; the PAT is never persisted in
+the image; pass with
+\verb{docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
 }
 \value{
 A R6 object of class \code{Dockerfile}.

--- a/man/dock_from_renv.Rd
+++ b/man/dock_from_renv.Rd
@@ -70,8 +70,8 @@ any PAT), \code{"build_arg"} (emit \verb{ARG GITHUB_PAT} + \code{ENV} propagatio
 pass with \verb{--build-arg GITHUB_PAT=$GITHUB_PAT}; the PAT will be
 visible in the image metadata), or \code{"secret"} (BuildKit secret
 mount on the \code{renv::restore()} RUN; the PAT is never persisted in
-the image; pass with
-\verb{docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
+the image; requires BuildKit, so pass with
+\verb{DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
 }
 \value{
 A R6 object of class \code{Dockerfile}.

--- a/man/dockerfiles.Rd
+++ b/man/dockerfiles.Rd
@@ -13,7 +13,8 @@ dock_from_desc(
   expand = FALSE,
   update_tar_gz = TRUE,
   build_from_source = TRUE,
-  extra_sysreqs = NULL
+  extra_sysreqs = NULL,
+  github_pat = c("none", "build_arg", "secret")
 )
 }
 \arguments{
@@ -38,6 +39,16 @@ the Dockerfile directly mount the source folder.}
 
 \item{extra_sysreqs}{character vector. Extra debian system requirements.
 Will be installed with apt-get install.}
+
+\item{github_pat}{character. How to provide a GitHub PAT to
+\code{remotes::install_github()} for private dependency repositories.
+One of \code{"none"} (default; the generated Dockerfile does not
+reference any PAT), \code{"build_arg"} (emit \verb{ARG GITHUB_PAT} + \code{ENV}
+propagation; pass with \verb{--build-arg GITHUB_PAT=$GITHUB_PAT}; the
+PAT will be visible in the image metadata), or \code{"secret"}
+(BuildKit secret mount on each \code{install_github()} / \code{install_local()}
+RUN; the PAT is never persisted in the image; pass with
+\verb{docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
 }
 \value{
 Dockerfile

--- a/man/dockerfiles.Rd
+++ b/man/dockerfiles.Rd
@@ -47,8 +47,9 @@ reference any PAT), \code{"build_arg"} (emit \verb{ARG GITHUB_PAT} + \code{ENV}
 propagation; pass with \verb{--build-arg GITHUB_PAT=$GITHUB_PAT}; the
 PAT will be visible in the image metadata), or \code{"secret"}
 (BuildKit secret mount on each \code{install_github()} / \code{install_local()}
-RUN; the PAT is never persisted in the image; pass with
-\verb{docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
+RUN; the PAT is never persisted in the image; requires BuildKit, so
+pass with
+\verb{DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
 }
 \value{
 Dockerfile

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -114,6 +114,45 @@ withr::with_dir(
 
 
     })
+
+    test_that("dock_from_desc emits no GITHUB_PAT plumbing by default", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(file.path(".", "DESCRIPTION__"))
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_false(grepl("GITHUB_PAT", df))
+      expect_false(grepl("--mount=type=secret", df, fixed = TRUE))
+    })
+
+    test_that("dock_from_desc emits ARG/ENV GITHUB_PAT when github_pat = 'build_arg'", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        github_pat = "build_arg"
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_match(df, "ARG GITHUB_PAT", fixed = TRUE)
+      expect_match(df, 'ENV "GITHUB_PAT"="${GITHUB_PAT}"', fixed = TRUE)
+      # No secret mount fragment in build_arg mode.
+      expect_false(grepl("--mount=type=secret", df, fixed = TRUE))
+    })
+
+    test_that("dock_from_desc emits secret mounts when github_pat = 'secret'", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        github_pat = "secret"
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      # No top-level ARG / ENV in secret mode.
+      expect_false(grepl("ARG GITHUB_PAT", df, fixed = TRUE))
+      expect_false(grepl('ENV "GITHUB_PAT"', df, fixed = TRUE))
+      # The install_local RUN must carry the secret-mount fragment.
+      expect_match(
+        df,
+        "--mount=type=secret,id=github_pat,env=GITHUB_PAT",
+        fixed = TRUE
+      )
+    })
   }
 )
 

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -146,10 +146,13 @@ withr::with_dir(
       # No top-level ARG / ENV in secret mode.
       expect_false(grepl("ARG GITHUB_PAT", df, fixed = TRUE))
       expect_false(grepl('ENV "GITHUB_PAT"', df, fixed = TRUE))
-      # The install_local RUN must carry the secret-mount fragment.
+      # The install_local RUN must carry the secret-mount fragment plus
+      # a `cat /run/secrets/...` shell prefix that exposes the PAT as
+      # an env var to the inner R command (compatible with all BuildKit
+      # versions, unlike the `env=GITHUB_PAT` shortcut on the mount).
       expect_match(
         df,
-        "--mount=type=secret,id=github_pat,env=GITHUB_PAT",
+        "--mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat)",
         fixed = TRUE
       )
     })

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -358,5 +358,55 @@ test_that("dock_from_renv preserves the user's PPM host on rewrite", {
   expect_false(grepl("packagemanager.posit.co", df, fixed = TRUE))
 })
 
+test_that("dock_from_renv emits no GITHUB_PAT plumbing by default", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_false(grepl("GITHUB_PAT", df))
+  expect_false(grepl("--mount=type=secret", df, fixed = TRUE))
+})
+
+test_that("dock_from_renv emits ARG/ENV GITHUB_PAT when github_pat = 'build_arg'", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    github_pat = "build_arg"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "ARG GITHUB_PAT", fixed = TRUE)
+  expect_match(df, 'ENV "GITHUB_PAT"="${GITHUB_PAT}"', fixed = TRUE)
+  expect_false(grepl("--mount=type=secret", df, fixed = TRUE))
+})
+
+test_that("dock_from_renv emits a secret mount on restore() when github_pat = 'secret'", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    github_pat = "secret"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_false(grepl("ARG GITHUB_PAT", df, fixed = TRUE))
+  expect_false(grepl('ENV "GITHUB_PAT"', df, fixed = TRUE))
+  expect_match(
+    df,
+    "--mount=type=secret,id=github_pat,env=GITHUB_PAT",
+    fixed = TRUE
+  )
+  # The renv cache mount must coexist with the secret mount on the same RUN.
+  expect_match(
+    df,
+    "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv --mount=type=secret,id=github_pat,env=GITHUB_PAT R -e 'renv::restore()'",
+    fixed = TRUE
+  )
+})
+
 unlink(dir_build, recursive = TRUE)
 

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -397,13 +397,13 @@ test_that("dock_from_renv emits a secret mount on restore() when github_pat = 's
   expect_false(grepl('ENV "GITHUB_PAT"', df, fixed = TRUE))
   expect_match(
     df,
-    "--mount=type=secret,id=github_pat,env=GITHUB_PAT",
+    "--mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat)",
     fixed = TRUE
   )
   # The renv cache mount must coexist with the secret mount on the same RUN.
   expect_match(
     df,
-    "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv --mount=type=secret,id=github_pat,env=GITHUB_PAT R -e 'renv::restore()'",
+    "--mount=type=cache,id=renv-cache,target=/root/.cache/R/renv --mount=type=secret,id=github_pat GITHUB_PAT=$(cat /run/secrets/github_pat) R -e 'renv::restore()'",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
## Summary

Reworks the idea originally proposed in #40 (private GitHub
dependencies during `docker build`) as a clean opt-in API on
`dock_from_desc()` and `dock_from_renv()`.

Three modes via a new `github_pat` parameter:

| mode | Dockerfile | invocation | PAT in image metadata? |
|---|---|---|---|
| \`"none"\` (default) | unchanged | n/a | n/a |
| \`"build_arg"\` | \`ARG GITHUB_PAT\` + \`ENV "GITHUB_PAT"="\${GITHUB_PAT}"\` near the top; install RUNs inherit the env | \`docker build --build-arg GITHUB_PAT=\$GITHUB_PAT ...\` | **yes**, visible |
| \`"secret"\` | each install RUN gets \`--mount=type=secret,id=github_pat,env=GITHUB_PAT\` | \`DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...\` | no, tmpfs only |

After generation, the user is reminded of the right invocation via
\`cli::cat_bullet()\`.

## Differences vs original PR #40

- **Opt-in instead of auto-detection.** PR #40 used \`gh::repo_get()\`
  to detect private repos at generation time, adding a \`gh\` dep + a
  network call. We avoid that — users explicitly pick the mode.
- **Adds the BuildKit secret mode** (recommended for published
  images), which the original PR did not cover.
- **Strictly orthogonal** to the \`sha256\` and \`use_suggests\` features
  also bundled in #40 — those deserve their own micro-PRs if wanted.

## Closes

Closes #40 — recommend closing the original PR with thanks; this one
keeps only the load-bearing PAT support, cleanly separated from the
unrelated features. References #18 (private repos roadmap).

## Test plan

- [x] \`devtools::test(filter = "dock_from")\` -> 81 PASS / 0 FAIL.
- [x] 3 new tests in \`test-dock_from_desc.R\`: default no-op,
      \`"build_arg"\` emits ARG/ENV, \`"secret"\` emits the mount fragment
      and no top-level ARG/ENV.
- [x] 3 parallel tests in \`test-dock_from_renv.R\`, plus an extra
      assertion that the existing renv-cache mount and the new secret
      mount coexist correctly on the same \`renv::restore()\` RUN.
- [x] Backward-compat: existing tests using the default \`github_pat\`
      pass unchanged (no GITHUB_PAT plumbing emitted).
- [x] \`devtools::document()\` regenerated \`man/dock_from_renv.Rd\` and
      \`man/dockerfiles.Rd\` (RoxygenNote reverted to 7.3.2).

Co-authored with @yogat3ch (original PR #40 author).