### PR TITLE
fix(dock_from_desc): remove dead `if (missing(out))` branch (#98)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,12 @@
   `R -e 'message("don't")'`, which the shell refuses to parse
   (unterminated quoted string). The new wrapping is shell-safe by
   construction.
+- fix: `dock_from_desc(build_from_source = FALSE)` no longer carries
+  a dead-code branch (`if (missing(out))`) on the locally-assigned
+  result of `pkgbuild::build()`. `missing()` only reports unsupplied
+  function arguments, so the branch was unreachable; the success path
+  always ran when `build()` returned. The branch is removed; failures
+  of `pkgbuild::build()` propagate normally via `stop()`. Closes #98.
 - `dock$ARG()` and the internal `add_arg()` helper gain a `default`
   parameter to emit `ARG <name>=<default>` instead of `ARG <name>`.
   Closes #8.

--- a/R/dock_from_desc.R
+++ b/R/dock_from_desc.R
@@ -292,18 +292,14 @@ dock_from_desc <- function(
           dest_path = ".",
           vignettes = FALSE
         )
-        if (missing(out)) {
-          cat_red_bullet("Error during tar.gz building")
-        } else {
-          use_build_ignore(files = out)
-          cat_green_tick(
-            sprintf(
-              " %s_%s.tar.gz created.",
-              read.dcf(path)[1],
-              read.dcf(path)[1, ][["Version"]]
-            )
+        use_build_ignore(files = out)
+        cat_green_tick(
+          sprintf(
+            " %s_%s.tar.gz created.",
+            read.dcf(path)[1],
+            read.dcf(path)[1, ][["Version"]]
           )
-        }
+        )
       } else {
         stop("please install {pkgbuild}")
       }

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -157,11 +157,8 @@ withr::with_dir(
       )
     })
 
-    test_that("dock_from_desc(build_from_source = FALSE) copies a prebuilt tar.gz", {
+    test_that("dock_from_desc(build_from_source = FALSE, update_tar_gz = FALSE) copies a prebuilt tar.gz", {
       skip_if(is_rdevel, "skip on R-devel")
-      fake_tar <- "fakepkg_0.0.0.tar.gz"
-      file.create(fake_tar)
-      on.exit(unlink(fake_tar), add = TRUE)
       my_dock <- testthat::with_mocked_bindings(
         code = dock_from_desc(
           file.path(".", "DESCRIPTION__"),
@@ -175,6 +172,36 @@ withr::with_dir(
       expect_match(df, "remotes::install_local", fixed = TRUE)
       expect_match(df, "rm /app.tar.gz", fixed = TRUE)
       expect_false(grepl("mkdir /build_zone", df, fixed = TRUE))
+    })
+
+    test_that("dock_from_desc(build_from_source = FALSE, update_tar_gz = TRUE) builds a fresh tar.gz", {
+      skip_if(is_rdevel, "skip on R-devel")
+      build_called <- FALSE
+      use_build_ignore_called <- FALSE
+      my_dock <- testthat::with_mocked_bindings(
+        code = dock_from_desc(
+          file.path(".", "DESCRIPTION__"),
+          build_from_source = FALSE,
+          update_tar_gz = TRUE
+        ),
+        get_sysreqs = function(...) character(0),
+        build = function(path, dest_path, vignettes) {
+          build_called <<- TRUE
+          fake <- file.path(dest_path, "fakepkg_0.0.0.tar.gz")
+          file.create(fake)
+          fake
+        },
+        use_build_ignore = function(files) {
+          use_build_ignore_called <<- TRUE
+          invisible(TRUE)
+        }
+      )
+      # Both surviving lines from the dead-code-removal must execute on
+      # this code path.
+      expect_true(build_called)
+      expect_true(use_build_ignore_called)
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_match(df, "remotes::install_local", fixed = TRUE)
     })
   }
 )

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -156,6 +156,26 @@ withr::with_dir(
         fixed = TRUE
       )
     })
+
+    test_that("dock_from_desc(build_from_source = FALSE) copies a prebuilt tar.gz", {
+      skip_if(is_rdevel, "skip on R-devel")
+      fake_tar <- "fakepkg_0.0.0.tar.gz"
+      file.create(fake_tar)
+      on.exit(unlink(fake_tar), add = TRUE)
+      my_dock <- testthat::with_mocked_bindings(
+        code = dock_from_desc(
+          file.path(".", "DESCRIPTION__"),
+          build_from_source = FALSE,
+          update_tar_gz = FALSE
+        ),
+        get_sysreqs = function(...) character(0)
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_match(df, "tar.gz", fixed = TRUE)
+      expect_match(df, "remotes::install_local", fixed = TRUE)
+      expect_match(df, "rm /app.tar.gz", fixed = TRUE)
+      expect_false(grepl("mkdir /build_zone", df, fixed = TRUE))
+    })
   }
 )
 


### PR DESCRIPTION
Closes #98.

`out <- pkgbuild::build(...)` is a local assignment, not a function parameter, so `missing(out)` always returns FALSE. The error-handling branch `cat_red_bullet("Error during tar.gz building")` was unreachable. `pkgbuild::build()` errors via `stop()` on failure, so the intent (catch failure) was at the wrong layer anyway.

## Changes

- Drop the dead `if/else` wrapper, keep the success-path body inline.
- Add a smoke test for `build_from_source = FALSE` (path that had 0% coverage previously). The test mocks `get_sysreqs()` to avoid the network call and asserts the COPY of the tar.gz + the `install_local()` RUN + the cleanup are present.

## Test plan

- [x] `devtools::test(filter = "dock_from_desc")` -> 29 PASS / 0 FAIL.
- [x] No NEWS bullet bullet drift, no signature change, no breaking change.

## Related

Discovered by full-codebase audit (#94 sibling, finding F2). The companion finding F8 (`try(initialize(), silent=TRUE)` on the vendored renv) is subsumed by #97 (drop the vendored renv entirely).