### PR TITLE
chore: small polish bundle (typos, dogfood, doc accuracy)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,7 +78,7 @@
   `. /etc/os-release && ` when the line uses `$VERSION_CODENAME`.
   User-pinned codenames and snapshot-date URLs (e.g. `cran/2024-01-15`)
   are preserved as-is. The user's PPM scheme and host (so a
-  `packagemanager.rstudio.com` URL stays on rstudio.com) is preserved
+  `packagemanager.rstudio.com` URL stays on rstudio.com) are preserved
   on rewrite. Non-PPM repos (including internal mirrors not on the
   official PPM hosts) and multi-entry `repos` vectors are left
   untouched.

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,13 +13,6 @@
 
 ## New features
 
-- chore: small polish bundle (no behavioural changes for end users):
-  fix two `length(x > 0)` typos in `dock_from_desc()` (intent was
-  `length(x) > 0`); drop a duplicate `@export` tag in `dockerignore.R`;
-  use the new `dock$ARG(name, default = ...)` form internally instead
-  of inlining the `=`; tighten a previously brittle regression test
-  that checked for any occurrence of `"remotes"` in the generated
-  Dockerfile.
 - `dock$ARG()` and the internal `add_arg()` helper gain a `default`
   parameter to emit `ARG <name>=<default>` instead of `ARG <name>`.
   Closes #8.
@@ -63,6 +56,13 @@
   function arguments, so the branch was unreachable; the success path
   always ran when `build()` returned. The branch is removed; failures
   of `pkgbuild::build()` propagate normally via `stop()`. Closes #98.
+- Small polish bundle (no behavioural changes for end users): fix two
+  `length(x > 0)` typos in `dock_from_desc()` (intent was
+  `length(x) > 0`); drop a duplicate `@export` tag in `dockerignore.R`;
+  use the new `dock$ARG(name, default = ...)` form internally instead
+  of inlining the `=`; tighten a previously brittle regression test
+  that checked for any occurrence of `"remotes"` in the generated
+  Dockerfile.
 
 
 # dockerfiler 0.2.6

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,7 @@
 
 - chore: small polish bundle (no behavioural changes for end users):
   fix two `length(x > 0)` typos in `dock_from_desc()` (intent was
-  `length(x) > 0`); drop fake-`{glue}` braces from a `stop()` message
-  in the same file; drop a duplicate `@export` tag in `dockerignore.R`;
+  `length(x) > 0`); drop a duplicate `@export` tag in `dockerignore.R`;
   use the new `dock$ARG(name, default = ...)` form internally instead
   of inlining the `=`; tighten a previously brittle regression test
   that checked for any occurrence of `"remotes"` in the generated

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@
 
 ## New features
 
+- chore: small polish bundle (no behavioural changes for end users):
+  fix two `length(x > 0)` typos in `dock_from_desc()` (intent was
+  `length(x) > 0`); drop fake-`{glue}` braces from a `stop()` message
+  in the same file; drop a duplicate `@export` tag in `dockerignore.R`;
+  use the new `dock$ARG(name, default = ...)` form internally instead
+  of inlining the `=`; tighten a previously brittle regression test
+  that checked for any occurrence of `"remotes"` in the generated
+  Dockerfile.
 - `dock$ARG()` and the internal `add_arg()` helper gain a `default`
   parameter to emit `ARG <name>=<default>` instead of `ARG <name>`.
   Closes #8.
@@ -70,9 +78,10 @@
   instead of the lockfile's repo URL; and the RUN is prefixed with
   `. /etc/os-release && ` when the line uses `$VERSION_CODENAME`.
   User-pinned codenames and snapshot-date URLs (e.g. `cran/2024-01-15`)
-  are preserved as-is. The user's PPM scheme and host (including
-  `packagemanager.rstudio.com` and internal mirrors) are preserved on
-  rewrite. Multi-entry `repos` vectors and non-PPM repos are left
+  are preserved as-is. The user's PPM scheme and host (so a
+  `packagemanager.rstudio.com` URL stays on rstudio.com) is preserved
+  on rewrite. Non-PPM repos (including internal mirrors not on the
+  official PPM hosts) and multi-entry `repos` vectors are left
   untouched.
 - `dock_from_renv()` no longer installs `remotes` when `renv_version = NULL`,
   since `remotes` was only needed for the `install_version()` path.

--- a/R/dock_from_desc.R
+++ b/R/dock_from_desc.R
@@ -209,7 +209,7 @@ dock_from_desc <- function(
 
   dock$RUN("R -e 'install.packages(\"remotes\")'")
 
-  if (length(packages_on_cran > 0)) {
+  if (length(packages_on_cran) > 0) {
     ping <- mapply(
       function(dock, ver, nm) {
         res <- dock$RUN(sprintf("Rscript -e 'remotes::install_version(\"%s\",upgrade=\"never\", version = %s)'",
@@ -221,7 +221,7 @@ dock_from_desc <- function(
     )
   }
 
-  if (length(packages_not_on_cran > 0)) {
+  if (length(packages_not_on_cran) > 0) {
     nn <- as.data.frame(
       do.call(
         rbind,
@@ -301,7 +301,7 @@ dock_from_desc <- function(
           )
         )
       } else {
-        stop("please install {pkgbuild}")
+        stop("please install pkgbuild")
       }
     }
     # we use an already built tar.gz file

--- a/R/dock_from_desc.R
+++ b/R/dock_from_desc.R
@@ -301,7 +301,7 @@ dock_from_desc <- function(
           )
         )
       } else {
-        stop("please install pkgbuild")
+        stop("please install {pkgbuild}")
       }
     }
     # we use an already built tar.gz file

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -105,7 +105,7 @@ dock_from_renv <- function(
     AS = AS
   )
   .github_pat_setup(dock, github_pat)
-  dock$ARG(sprintf("RENV_PATHS_CACHE=%s", renv_paths_cache))
+  dock$ARG("RENV_PATHS_CACHE", default = renv_paths_cache)
   dock$ENV(key = "RENV_PATHS_CACHE", value = "${RENV_PATHS_CACHE}")
   if (!is.null(user)) {
     dock$USER(user)
@@ -313,8 +313,11 @@ dock_from_renv <- function(
 
   # Strip a single trailing slash so `cran/latest/` matches `cran/latest`.
   user_url_norm <- sub("/$", "", user_url)
-  # Preserve the user's scheme + host (so a `packagemanager.rstudio.com`
-  # URL or an internal mirror is not silently rewritten to posit.co).
+  # Preserve the user's scheme + host on rewrite (so a
+  # `packagemanager.rstudio.com` URL stays on rstudio.com and is not
+  # silently swapped to posit.co). The PPM detection regex above only
+  # matches the two official PPM hosts; non-PPM internal mirrors are
+  # not entered into this branch at all.
   user_host_prefix <- sub("/cran(/.*)?$", "", user_url_norm)
 
   # Only rewrite when the URL is the bare `cran` or `cran/latest` form.

--- a/R/dockerignore.R
+++ b/R/dockerignore.R
@@ -7,8 +7,6 @@
 #' @importFrom fs path file_exists file_create
 #' @importFrom cli cat_bullet
 #'
-#' @export
-#'
 #' @examples
 #' \dontrun{
 #'   docker_ignore_add()

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -210,10 +210,17 @@ socle_install_version <- "remotes::install_version\\(\"renv\", version = \""
   installs_latest <- is.null(renv_version) ||
     (identical(renv_version, "missing") && lf == the_lockfile)
   if (installs_latest) {
-    # When using the latest renv, `remotes` must not be installed at all.
+    # When using the latest renv, `remotes` must not be installed at
+    # all. Tighter regex than `grepl("remotes", ...)` so we don't
+    # false-positive on incidental occurrences of the substring (e.g.
+    # a host name) elsewhere in the Dockerfile.
     expect_false(
       any(grepl("install\\.packages\\([^)]*remotes", out$Dockerfile)),
       info = paste(lf, " & ", renv_version, " => no remotes install")
+    )
+    expect_false(
+      any(grepl("remotes::install_version", out$Dockerfile)),
+      info = paste(lf, " & ", renv_version, " => no remotes::install_version")
     )
   }
 


### PR DESCRIPTION
Cosmetic / hygiene changes from the post-0.2.6 audit. **No behavioural
changes for end users.** Bundled to avoid 6 micro-PRs for purely
stylistic stuff.

## Changes

- **F3** `R/dock_from_desc.R` x2: `length(packages_on_cran > 0)` was
  a typo for `length(packages_on_cran) > 0` (the parens encompassed
  the comparison). The buggy form happened to evaluate to the right
  truthy value because `length(<bool_vec>) == length(<input_vec>)`,
  but the intent is now obvious. Same fix on `packages_not_on_cran`.
- **F4** `R/dock_from_desc.R`: drop fake-`{glue}` braces from
  `stop("please install {pkgbuild}")`. The string was not
  interpolated, so end users hitting that error saw the literal
  `{pkgbuild}` text.
- **F7** `R/dockerignore.R`: duplicate `@export` tag removed.
- **G1** `R/dock_from_renv.R`: dogfood the new `dock$ARG(name, default = ...)` form (added in #91) instead of inlining the `=` via `sprintf()`. Identical Dockerfile output, just goes through the public API.
- **G2** `R/dock_from_renv.R` + `NEWS.md` 0.2.6 bullet: clarify that the PPM patch only fires on the official `posit.co` / `rstudio.com` PPM hosts. The previous wording suggested internal mirrors were "preserved on rewrite", but the PPM detection regex doesn't match them at all - they fall through and are simply left untouched (which is the correct outcome, just not via the rewrite branch).
- **G4** `tests/testthat/test-dock_from_renv.R`: tighten
  `expect_false(any(grepl("remotes", ...)))` to
  `grepl("install\\.packages\\([^)]*remotes", ...)` + a check for
  `remotes::install_version`. The previous form was brittle - any
  future incidental occurrence of the substring "remotes" anywhere
  in the generated Dockerfile (e.g. in a host name) would
  false-positive.

## NOT in this bundle

- **F5** (`lifecycle::deprecate_warn()` for the `distro` deprecation):
  requires adding `lifecycle` to `Imports:`, deferred for separate
  decision.
- F2, F6, F9, F10 from earlier audits: covered in PR #99 (dead-code)
  and the planned coverage PR.

## Test plan

- [x] `devtools::test()` -> 150 PASS / 0 FAIL.
- No new tests needed: 5 of the 6 changes are cosmetic / refactor with
  byte-identical output. G4 strengthens an existing test rather than
  adding one.