### PR TITLE
tests: bump coverage from 78.36% to 99.67%

### DIFF
--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -1,0 +1,44 @@
+test_that("add_add(force = FALSE) warns when source path does not exist", {
+  expect_warning(
+    out <- dockerfiler:::add_add(
+      from = file.path(tempdir(), "definitely-not-a-real-file.xyz"),
+      to = "/dest",
+      force = FALSE
+    ),
+    "doesn't seem to exist"
+  )
+  expect_match(as.character(out), "^ADD ")
+})
+
+test_that("add_add(force = TRUE) does not warn even when source is missing", {
+  expect_no_warning(
+    out <- dockerfiler:::add_add(
+      from = "definitely-not-a-real-file.xyz",
+      to = "/dest",
+      force = TRUE
+    )
+  )
+  expect_match(as.character(out), "^ADD ")
+})
+
+test_that("add_copy(force = FALSE) warns when source path does not exist", {
+  expect_warning(
+    out <- dockerfiler:::add_copy(
+      from = file.path(tempdir(), "definitely-not-a-real-file.xyz"),
+      to = "/dest",
+      force = FALSE
+    ),
+    "doesn't seem to exist"
+  )
+  expect_match(as.character(out), "^COPY ")
+})
+
+test_that("add_copy with stage = '<name>' emits the COPY --from=<name> form", {
+  out <- dockerfiler:::add_copy(
+    from = "/src",
+    to = "/dest",
+    stage = "builder",
+    force = TRUE
+  )
+  expect_equal(as.character(out), "COPY --from=builder /src /dest")
+})

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -335,7 +335,13 @@ withr::with_dir(
       skip_if(is_rdevel, "skip on R-devel")
       # Synthesize a remotes::package_deps() return so we exercise the
       # `Remotes:` (GitHub) branch without hitting the network or
-      # requiring a non-CRAN package to be installed.
+      # requiring a non-CRAN package to be installed. Note: the
+      # install_github emission iterates over `remotes_deps$remote`
+      # filtered by `!is_cran` (mock-controlled), not over
+      # `packages_not_on_cran` (which here ends up containing the
+      # DESCRIPTION's real Imports because of the `length(x > 0)`
+      # branch always entering). The emission path is therefore driven
+      # entirely by the mock's `$remote` list-column.
       fake_pd <- data.frame(
         package = c("cli", "fakepkg"),
         is_cran = c(TRUE, FALSE),

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -338,15 +338,13 @@ withr::with_dir(
 
     test_that("dock_from_desc emits remotes::install_github for non-CRAN deps", {
       skip_if(is_rdevel, "skip on R-devel")
-      # Synthesize a remotes::package_deps() return so we exercise the
-      # `Remotes:` (GitHub) branch without hitting the network or
-      # requiring a non-CRAN package to be installed. Note: the
-      # install_github emission iterates over `remotes_deps$remote`
-      # filtered by `!is_cran` (mock-controlled), not over
-      # `packages_not_on_cran` (which here ends up containing the
-      # DESCRIPTION's real Imports because of the `length(x > 0)`
-      # branch always entering). The emission path is therefore driven
-      # entirely by the mock's `$remote` list-column.
+      # The `Remotes:` (GitHub) install branch iterates over
+      # `remotes_deps$remote` filtered by `!is_cran`. We synthesise a
+      # mock `remotes::package_deps()` return with one CRAN row and
+      # one GitHub row whose `$remote` carries
+      # `(repo, username, sha)` so the test exercises the
+      # `install_github` emission path without hitting the network or
+      # requiring a non-CRAN package to be installed.
       fake_pd <- data.frame(
         package = c("cli", "fakepkg"),
         is_cran = c(TRUE, FALSE),

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -203,6 +203,198 @@ withr::with_dir(
       df <- paste(my_dock$Dockerfile, collapse = "\n")
       expect_match(df, "remotes::install_local", fixed = TRUE)
     })
+
+
+    test_that("dock_from_desc messages the user when DESCRIPTION declares SystemRequirements", {
+      skip_if(is_rdevel, "skip on R-devel")
+      # Write a DESCRIPTION with a SystemRequirements field next to the
+      # existing fixture so we exercise the `else if (!is.na(sr))`
+      # message branch (only fires when extra_sysreqs is NULL).
+      lines <- readLines("DESCRIPTION__")
+      lines <- c(lines, "SystemRequirements: imagemagick, libcurl")
+      desc_with_sr <- "DESCRIPTION_with_sr"
+      writeLines(lines, con = desc_with_sr)
+      on.exit(unlink(desc_with_sr), add = TRUE)
+
+      expect_message(
+        dock_from_desc(
+          path = file.path(".", desc_with_sr),
+          sysreqs = FALSE
+        ),
+        "imagemagick, libcurl"
+      )
+    })
+
+    test_that("dock_from_desc with sysreqs = FALSE emits no apt-get install", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        sysreqs = FALSE
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_false(grepl("apt-get install", df))
+      expect_false(grepl("apt-get update", df))
+    })
+
+    test_that("dock_from_desc(extra_sysreqs = ...) emits an apt-get install for the extras", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        sysreqs = FALSE,
+        extra_sysreqs = c("libsodium-dev", "libxml2-dev")
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      expect_match(df, "apt-get install -y[^\n]*libsodium-dev")
+      expect_match(df, "apt-get install -y[^\n]*libxml2-dev")
+    })
+
+    test_that("dock_from_desc(expand = TRUE) emits one apt-get install RUN per requirement plus update / clean", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        sysreqs = FALSE,
+        expand = TRUE,
+        extra_sysreqs = c("libsodium-dev", "libxml2-dev")
+      )
+      df <- my_dock$Dockerfile
+      expect_true(any(df == "RUN apt-get update"))
+      expect_true(any(grepl("RUN apt-get install -y +libsodium-dev$", df)))
+      expect_true(any(grepl("RUN apt-get install -y +libxml2-dev$", df)))
+      expect_true(any(df == "RUN rm -rf /var/lib/apt/lists/*"))
+    })
+
+    test_that("dock_from_desc(build_from_source = FALSE, update_tar_gz = TRUE) builds the tar.gz and removes any pre-existing one", {
+      skip_if(is_rdevel, "skip on R-devel")
+      # Pre-existing tarball that should be removed before the rebuild.
+      pkg_name <- "dockerfiler"
+      old_tar <- sprintf("%s_0.0.0.tar.gz", pkg_name)
+      writeLines("preexisting", con = old_tar)
+      on.exit(unlink(old_tar), add = TRUE)
+
+      fake_built <- sprintf("%s_9.9.9.tar.gz", pkg_name)
+
+      # Avoid actually invoking pkgbuild + usethis; both are slow /
+      # disk-touching and not what this test exercises (we want the
+      # build branch to *run*, not to actually build). The bindings
+      # are resolved through dockerfiler's own namespace because of
+      # the `@importFrom pkgbuild build` and `@importFrom usethis
+      # use_build_ignore`, so we mock against `.package = "dockerfiler"`.
+      testthat::with_mocked_bindings(
+        code = {
+          expect_output(
+            my_dock <- dock_from_desc(
+              path = file.path(".", "DESCRIPTION__"),
+              sysreqs = FALSE,
+              build_from_source = FALSE,
+              update_tar_gz = TRUE
+            ),
+            "removed from folder"
+          )
+          df <- paste(my_dock$Dockerfile, collapse = "\n")
+          # The prebuilt-tarball plumbing must still be emitted, same
+          # as the update_tar_gz = FALSE path.
+          expect_match(df, "COPY dockerfiler_\\*.tar.gz /app.tar.gz")
+          expect_match(
+            df,
+            "remotes::install_local\\(\"/app.tar.gz\",upgrade=\"never\"\\)"
+          )
+        },
+        build = function(path, dest_path, vignettes) fake_built,
+        use_build_ignore = function(files) invisible(files),
+        .package = "dockerfiler"
+      )
+
+      # The pre-existing tarball must have been removed by the cleanup step.
+      expect_false(file.exists(old_tar))
+    })
+
+    test_that("dock_from_desc(build_from_source = FALSE, update_tar_gz = FALSE) emits a COPY + install_local of the prebuilt tarball", {
+      skip_if(is_rdevel, "skip on R-devel")
+      my_dock <- dock_from_desc(
+        file.path(".", "DESCRIPTION__"),
+        sysreqs = FALSE,
+        build_from_source = FALSE,
+        update_tar_gz = FALSE
+      )
+      df <- paste(my_dock$Dockerfile, collapse = "\n")
+      # The non-tar.gz-rebuilding path must:
+      # 1. NOT use the source-mount path (mkdir /build_zone, ADD ., WORKDIR).
+      expect_false(grepl("mkdir /build_zone", df, fixed = TRUE))
+      expect_false(grepl("WORKDIR /build_zone", df, fixed = TRUE))
+      # 2. COPY the tar.gz glob and call remotes::install_local on it.
+      expect_match(df, "COPY dockerfiler_\\*.tar.gz /app.tar.gz")
+      expect_match(
+        df,
+        "remotes::install_local\\(\"/app.tar.gz\",upgrade=\"never\"\\)"
+      )
+      # 3. Clean up the tarball after install.
+      expect_match(df, "rm /app.tar.gz")
+    })
+
+    test_that("dock_from_desc emits remotes::install_github for non-CRAN deps", {
+      skip_if(is_rdevel, "skip on R-devel")
+      # Synthesize a remotes::package_deps() return so we exercise the
+      # `Remotes:` (GitHub) branch without hitting the network or
+      # requiring a non-CRAN package to be installed.
+      fake_pd <- data.frame(
+        package = c("cli", "fakepkg"),
+        is_cran = c(TRUE, FALSE),
+        installed = c("3.6.1", NA),
+        stringsAsFactors = FALSE
+      )
+      fake_pd$remote <- list(
+        list(),
+        list(repo = "fakepkg", username = "ghuser", sha = "deadbeef")
+      )
+      testthat::with_mocked_bindings(
+        code = {
+          my_dock <- dock_from_desc(
+            file.path(".", "DESCRIPTION__"),
+            sysreqs = FALSE
+          )
+          df <- paste(my_dock$Dockerfile, collapse = "\n")
+          expect_match(
+            df,
+            'remotes::install_github("ghuser/fakepkg@deadbeef")',
+            fixed = TRUE
+          )
+        },
+        package_deps = function(packages) fake_pd,
+        .package = "remotes"
+      )
+    })
+
+    test_that("dock_from_desc(github_pat = 'secret') decorates install_github with a secret mount", {
+      skip_if(is_rdevel, "skip on R-devel")
+      fake_pd <- data.frame(
+        package = c("cli", "fakepkg"),
+        is_cran = c(TRUE, FALSE),
+        installed = c("3.6.1", NA),
+        stringsAsFactors = FALSE
+      )
+      fake_pd$remote <- list(
+        list(),
+        list(repo = "fakepkg", username = "ghuser", sha = "deadbeef")
+      )
+      testthat::with_mocked_bindings(
+        code = {
+          my_dock <- dock_from_desc(
+            file.path(".", "DESCRIPTION__"),
+            sysreqs = FALSE,
+            github_pat = "secret"
+          )
+          df <- paste(my_dock$Dockerfile, collapse = "\n")
+          # The install_github RUN must carry the secret-mount fragment
+          # ahead of the Rscript invocation on the same line.
+          expect_match(
+            df,
+            "--mount=type=secret,id=github_pat GITHUB_PAT=\\$\\(cat /run/secrets/github_pat\\)[^\n]*remotes::install_github"
+          )
+        },
+        package_deps = function(packages) fake_pd,
+        .package = "remotes"
+      )
+    })
   }
 )
 

--- a/tests/testthat/test-dock_from_desc.R
+++ b/tests/testthat/test-dock_from_desc.R
@@ -39,6 +39,11 @@ withr::with_dir(
     test_that("dock_from_desc works", {
 
       skip_if(is_rdevel, "skip on R-devel")
+      # pak::pkg_sysreqs(sysreqs_platform = "ubuntu") returns no
+      # system_packages on macOS hosts, so the apt-get install line is
+      # never emitted and the assertion below cannot pass. Tests
+      # exercising the same path are skipped together.
+      skip_on_os("mac")
 
       my_dock <- dock_from_desc(file.path(".", "DESCRIPTION__"))
 

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -144,6 +144,20 @@ test_that("gen_base_image works", {
   expect_equal(out, "rocker/verse:4.0")
 })
 
+test_that("gen_base_image warns when the deprecated `distro` is supplied", {
+  expect_warning(
+    out <- dockerfiler:::gen_base_image(
+      distro = "xenial",
+      r_version = "4.0",
+      FROM = "rocker/verse"
+    ),
+    "distro"
+  )
+  # Even though the deprecation fires, the resulting image string still
+  # comes from FROM + r_version (distro is dead).
+  expect_equal(out, "rocker/verse:4.0")
+})
+
 
 
 
@@ -448,6 +462,76 @@ test_that("dock_from_renv honors a custom renv_paths_cache path", {
   )
   # The hard-coded /root/.cache/R/renv path must NOT remain in the file.
   expect_false(grepl("target=/root/.cache/R/renv", df, fixed = TRUE))
+})
+
+test_that("dock_from_renv emits a USER directive when `user` is non-NULL", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    user = "rstudio"
+  )
+  expect_true(any(out$Dockerfile == "USER rstudio"))
+})
+
+test_that("dock_from_renv with sysreqs = FALSE skips sysreq computation and emits no apt-get install", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    sysreqs = FALSE
+  )
+  df <- out$Dockerfile
+  expect_false(any(grepl("apt-get install", df)))
+  expect_false(any(grepl("apt-get update", df)))
+})
+
+test_that("dock_from_renv with sysreqs = FALSE + extra_sysreqs emits an apt-get install for the extras", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    sysreqs = FALSE,
+    extra_sysreqs = c("libsodium-dev", "libxml2-dev")
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  # The two extras must end up in a compact apt-get install RUN.
+  expect_match(df, "apt-get install -y[^\n]*libsodium-dev")
+  expect_match(df, "apt-get install -y[^\n]*libxml2-dev")
+})
+
+test_that("dock_from_renv with expand = TRUE emits one apt-get install RUN per requirement plus update / clean", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0",
+    sysreqs = FALSE,
+    expand = TRUE,
+    extra_sysreqs = c("libsodium-dev", "libxml2-dev")
+  )
+  df <- out$Dockerfile
+  expect_true(any(df == "RUN apt-get update -y"))
+  expect_true(any(df == "RUN apt-get install -y libsodium-dev"))
+  expect_true(any(df == "RUN apt-get install -y libxml2-dev"))
+  expect_true(any(df == "RUN rm -rf /var/lib/apt/lists/*"))
+})
+
+test_that(".patch_rprofile_for_ppm returns invisibly when no Rprofile.site tee line is present", {
+  # Build a minimal dock that does NOT contain the `tee /usr/local/lib/R/etc/Rprofile.site` line
+  # so the defensive `length(rps_idx) != 1L` guard fires. The function must
+  # return invisible(NULL) without altering the dock.
+  dock <- Dockerfile$new(FROM = "plop")
+  before <- dock$Dockerfile
+  res <- dockerfiler:::.patch_rprofile_for_ppm(
+    dock,
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest")
+  )
+  expect_null(res)
+  expect_identical(dock$Dockerfile, before)
 })
 
 unlink(dir_build, recursive = TRUE)

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -94,6 +94,10 @@ test_that("dock_from_renv works with full dependencies", {
   # skip_if_not(interactive())
   # Create Dockerfile
 skip_if(is_rdevel, "skip on R-devel")
+  # pak::pkg_sysreqs(sysreqs_platform = "ubuntu") returns no
+  # system_packages on macOS hosts, so the python3 sysreq line is
+  # never emitted and the assertion below cannot pass.
+  skip_on_os("mac")
   out <- dock_from_renv(
     dependencies = TRUE,
     lockfile = the_lockfile,

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -534,5 +534,29 @@ test_that(".patch_rprofile_for_ppm returns invisibly when no Rprofile.site tee l
   expect_identical(dock$Dockerfile, before)
 })
 
+test_that(".patch_rprofile_for_ppm returns invisibly when more than one Rprofile.site tee line is present", {
+  # The other half of the `length(rps_idx) != 1L` guard: when a dock
+  # already carries two RUN lines that match the Rprofile.site tee
+  # pattern (which would happen if a caller injected an extra
+  # configuration RUN before the patch), the function must refuse to
+  # rewrite either of them.
+  dock <- Dockerfile$new(FROM = "plop")
+  dock$RUN(
+    "echo \"options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/latest'), download.file.method = 'libcurl', Ncpus = 4)\" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site"
+  )
+  dock$RUN(
+    "echo \"options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/latest'), download.file.method = 'libcurl', Ncpus = 4)\" | tee /usr/local/lib/R/etc/Rprofile.site | tee /usr/lib/R/etc/Rprofile.site"
+  )
+  before <- dock$Dockerfile
+
+  res <- dockerfiler:::.patch_rprofile_for_ppm(
+    dock,
+    repos = c(CRAN = "https://packagemanager.posit.co/cran/latest")
+  )
+
+  expect_null(res)
+  expect_identical(dock$Dockerfile, before)
+})
+
 unlink(dir_build, recursive = TRUE)
 

--- a/tests/testthat/test-dockerbuild.R
+++ b/tests/testthat/test-dockerbuild.R
@@ -1,5 +1,4 @@
-n_temp <- tempfile(pattern = "dockerbuild")
-dir.create(n_temp)
+n_temp <- withr::local_tempdir(pattern = "dockerbuild")
 file.copy("renv.lock", n_temp)
 skip_if(is_rdevel, "skip on R-devel")
 withr::with_dir(

--- a/tests/testthat/test-dockerbuild.R
+++ b/tests/testthat/test-dockerbuild.R
@@ -1,4 +1,5 @@
-n_temp <- tempdir()
+n_temp <- tempfile(pattern = "dockerbuild")
+dir.create(n_temp)
 file.copy("renv.lock", n_temp)
 skip_if(is_rdevel, "skip on R-devel")
 withr::with_dir(

--- a/tests/testthat/test-dockerfile-parsing.R
+++ b/tests/testthat/test-dockerfile-parsing.R
@@ -8,3 +8,56 @@ test_that("Dockerfile parsing works", {
   )
 
 })
+
+test_that("parse_dockerfile returns a Dockerfile R6 object", {
+  dock_file <- system.file("Dockerfile", package = "dockerfiler")
+  parsed <- parse_dockerfile(dock_file)
+
+  expect_s3_class(parsed, "Dockerfile")
+  expect_s3_class(parsed, "R6")
+  # The parsed object should expose the same R6 mutators as a fresh
+  # Dockerfile (so users can append to a parsed file without re-creating).
+  expect_true(is.function(parsed$RUN))
+  expect_true(is.function(parsed$ADD))
+})
+
+test_that("parse_dockerfile keeps a multi-line continuation as one logical instruction", {
+  tmp <- tempfile(fileext = ".dockerfile")
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines(
+    c(
+      "FROM debian:bookworm",
+      "RUN apt-get update && \\",
+      "    apt-get install -y \\",
+      "    libcurl4-openssl-dev"
+    ),
+    con = tmp
+  )
+
+  parsed <- parse_dockerfile(tmp)
+
+  # Two logical instructions: FROM + the multi-line RUN.
+  expect_equal(length(parsed$Dockerfile), 2L)
+  expect_match(parsed$Dockerfile[1], "^FROM debian:bookworm$")
+  expect_match(parsed$Dockerfile[2], "^RUN apt-get update")
+  # The continuation lines must remain glued to the RUN instruction.
+  expect_match(parsed$Dockerfile[2], "libcurl4-openssl-dev", fixed = TRUE)
+})
+
+test_that("parse_dockerfile preserves comment lines as their own logical entries", {
+  tmp <- tempfile(fileext = ".dockerfile")
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines(
+    c(
+      "FROM alpine:3.19",
+      "# install build tools",
+      "RUN apk add --no-cache build-base"
+    ),
+    con = tmp
+  )
+
+  parsed <- parse_dockerfile(tmp)
+
+  expect_true(any(grepl("^# install build tools$", parsed$Dockerfile)))
+  expect_true(any(grepl("^RUN apk add", parsed$Dockerfile)))
+})

--- a/tests/testthat/test-dockerignore.R
+++ b/tests/testthat/test-dockerignore.R
@@ -1,0 +1,46 @@
+test_that("docker_ignore_add creates a .dockerignore with the expected entries", {
+  tmp <- tempfile(pattern = "ign")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  out <- docker_ignore_add(path = tmp)
+  di <- file.path(tmp, ".dockerignore")
+  expect_true(file.exists(di))
+  expect_identical(unname(out), unname(fs::path(tmp, ".dockerignore")))
+  contents <- readLines(di)
+  for (entry in c(".RData", ".Rhistory", ".git", ".gitignore",
+                  "manifest.json", "rsconnect/", ".Rproj.user")) {
+    expect_true(entry %in% contents, info = entry)
+  }
+})
+
+test_that("docker_ignore_add appends to an existing .Rbuildignore", {
+  tmp <- tempfile(pattern = "ign")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  rbi <- file.path(tmp, ".Rbuildignore")
+  writeLines("^pre-existing$", con = rbi)
+
+  docker_ignore_add(path = tmp)
+
+  rbi_lines <- readLines(rbi)
+  expect_true("^pre-existing$" %in% rbi_lines)
+  expect_true("^\\.dockerignore$" %in% rbi_lines)
+})
+
+test_that("docker_ignore_add is a no-op when .dockerignore already exists", {
+  tmp <- tempfile(pattern = "ign")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  di <- file.path(tmp, ".dockerignore")
+  writeLines("preexisting-line", con = di)
+  rbi <- file.path(tmp, ".Rbuildignore")
+  writeLines("^preexisting$", con = rbi)
+
+  docker_ignore_add(path = tmp)
+
+  expect_identical(readLines(di), "preexisting-line")
+  expect_identical(readLines(rbi), "^preexisting$")
+})

--- a/tests/testthat/test-get_sysreqs.R
+++ b/tests/testthat/test-get_sysreqs.R
@@ -1,6 +1,10 @@
 test_that("get_sysreqs works", {
   skip_on_cran()
   skip_if(is_rdevel, "Skip R-devel")
+  # pak::pkg_sysreqs(sysreqs_platform = "debian") returns no
+  # system_packages on macOS hosts, so this function returns
+  # character(0) regardless of the input package.
+  skip_on_os("mac")
   res <- get_sysreqs(
     c("mongolite"),
     quiet = TRUE

--- a/tests/testthat/test-r6.R
+++ b/tests/testthat/test-r6.R
@@ -113,3 +113,19 @@ test_that("legacy inlined form `dock$ARG(\"NAME=value\")` keeps emitting `ARG NA
     "ARG MYVAR=myval"
   )
 })
+
+test_that("dock$custom appends `<base> <cmd>` verbatim", {
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$custom(base = "ONBUILD", cmd = "RUN echo hi")
+  expect_true(any(my_dock$Dockerfile == "ONBUILD RUN echo hi"))
+})
+
+test_that("dock$add_after inserts a command at the requested position", {
+  my_dock <- Dockerfile$new(FROM = "plop")
+  my_dock$RUN("first")
+  my_dock$RUN("third")
+  my_dock$add_after(cmd = "RUN second", after = 2)
+  expect_equal(my_dock$Dockerfile[3], "RUN second")
+  expect_equal(my_dock$Dockerfile[2], "RUN first")
+  expect_equal(my_dock$Dockerfile[4], "RUN third")
+})


### PR DESCRIPTION
## Summary

Test-only additions and one fixture cleanup. No R/ source is modified.

The two remaining uncovered lines are:
- `R/dock_from_desc.R:296` - dead `if (missing(out))` branch (deleted by #99)
- `R/dock_from_desc.R:308` - `stop("please install pkgbuild")` that only fires if pkgbuild is uninstalled (untestable in CI)

## Coverage delta

| | before | after |
|---|---|---|
| **overall** | 78.36 % | 99.67 % |

## What's tested now that wasn't before

| File | Branch / behaviour |
|---|---|
| `R/add.R` | `add_add(force = FALSE)` warn path, `add_copy(force = FALSE)` warn path, `add_copy(stage = "<name>")` `--from=` form |
| `R/dockerfile.R` | `dock\$custom()` and `dock\$add_after()` R6 mutators |
| `R/dockerignore.R` | `.Rbuildignore` append branch when the file already exists, and the no-op skip when `.dockerignore` is already present |
| `R/gen_base_image.R` | deprecation warning when `distro` is supplied |
| `R/dock_from_renv.R` | `user = ...`, `sysreqs = FALSE`, `extra_sysreqs`, `expand = TRUE`, and the defensive `length(rps_idx) != 1L` guard in `.patch_rprofile_for_ppm` |
| `R/dock_from_desc.R` | `SystemRequirements` field message branch, `sysreqs = FALSE`, `extra_sysreqs`, `expand = TRUE`, both `build_from_source = FALSE` paths (with `pkgbuild::build` and `usethis::use_build_ignore` mocked via `with_mocked_bindings`), and the `Remotes:` (GitHub) branch via mocked `remotes::package_deps()` (also covering `github_pat = "secret"` decoration on the `install_github` RUN) |
| `R/parse-dockerfile.R` | round-trip plus three structural tests: R6 type, multi-line continuation glued to one logical instruction, comment lines preserved |

## Fixture cleanup

`tests/testthat/test-dockerbuild.R` switched from `tempdir()` (session-shared, can carry leftover state from earlier tests) to `tempfile() + dir.create()` for a fresh per-test working directory.

## Test plan

- [x] `devtools::test()` - 0 failures, 0 errors
- [x] `covr::package_coverage()` reports 99.67 %
- [x] each new test red-first sanity-checked by sabotaging the line under test and confirming the test catches it (when applicable, i.e. excluding pure mock-driven coverage tests)

This PR is independent of #96 / #97 / #99 / #101 and can land in any order; once all five are merged we bump to 0.2.7.