### PR TITLE
docs(vignette): point install_github at ThinkR-open instead of colinfay

### DIFF
--- a/vignettes/dockerfiler.Rmd
+++ b/vignettes/dockerfiler.Rmd
@@ -26,7 +26,7 @@ You can install dockerfiler from GitHub with:
 
 ```{r gh-installation, eval = FALSE}
 # install.packages("remotes")
-remotes::install_github("colinfay/dockerfiler")
+remotes::install_github("ThinkR-open/dockerfiler")
 ```
 
 Or from CRAN with : 


### PR DESCRIPTION
## Summary

The Getting Started vignette has a stale fork reference:

```r
remotes::install_github("colinfay/dockerfiler")
```

The package lives under `ThinkR-open/dockerfiler` since 2021. A CRAN
reviewer or new user copy-pasting that line would install a stale
fork that has none of the 0.2.x or 0.3.0 features. This is the
single CRAN-blocking documentation issue surfaced by the pre-CRAN
audit (see local prep report).

## Test plan

- [x] One-line change in `vignettes/dockerfiler.Rmd`.
- [x] `R CMD check --as-cran` -> 0 errors / 0 warnings / 0 notes
      (verified locally on `poc/doc-vignette-fork-rename`, 2m 38s).
- [x] No NAMESPACE / Rd impact (vignette-only edit).

## Context

Étape 1 / 8 of the 0.3.0 CRAN-prep plan. Subsequent doc polish PRs
will follow as a separate bundled PR (étape 2).