### PR TITLE
feat(dock_from_renv): default to non-root user 'rstudio' out of the box

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,19 @@
   argument is missing and the lockfile does not pin renv, is now
   `NULL` (install the latest renv from the configured repos), aligned
   with the existing `renv_version = NULL` behaviour. Closes #94.
+- `dock_from_renv()` now defaults to running the runtime container as
+  the `rstudio` user (previously root). The generated Dockerfile gains
+  a defensive `RUN id -u rstudio || useradd -m -d /home/rstudio -s /bin/bash rstudio`
+  early so the user is created if the FROM image does not already
+  ship one (no-op on rocker/* images, real `useradd` on `r-base`,
+  `ubuntu:*`, `debian:*`). The renv cache is auto-derived to
+  `/home/<user>/.cache/R/renv` and chowned to `<user>` before the
+  `USER` directive drops privilege; the `USER` directive itself is
+  emitted right before the `renv::restore()` cache-mount RUN, so
+  every step that needs root (apt-get, R installs) still runs as
+  root. Pass `user = NULL` to opt out and keep the previous root
+  behaviour. debian/ubuntu only; for alpine-based images you must
+  pass `user = NULL` and create the user yourself. Closes #100.
 
 ## New features
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -29,7 +29,38 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   - a character string such as `"1.0.0"`: install that specific
 #'     version regardless of what the lockfile says.
 #' @param use_pak boolean. If `TRUE` use pak to deal with dependencies  during `renv::restore()`. FALSE by default
-#' @param user Name of the user to specify in the Dockerfile with the USER instruction. Default is `NULL`, in which case the user from the FROM image is used.
+#' @param user Name of the user the runtime container drops privilege
+#'   to before the `renv::restore()` step (and therefore at runtime).
+#'   Default is `"rstudio"` so the generated image runs as a non-root
+#'   user out of the box, which is the recommended security posture.
+#'
+#'   The Dockerfile is emitted in two halves: every step that needs
+#'   root (apt-get, R install commands, `chown` of the renv cache)
+#'   runs first; then a `USER <user>` directive drops privilege; then
+#'   the `renv::restore()` cache-mount RUN happens.
+#'
+#'   To make this work regardless of the FROM image, the package
+#'   emits a defensive `RUN id -u <user> >/dev/null 2>&1 ||
+#'   useradd -m -d /home/<user> -s /bin/bash <user>` early. On
+#'   rocker/* images the `useradd` is a no-op (the user already
+#'   exists); on `r-base`, `ubuntu:*`, `debian:*` it creates the user
+#'   with the standard home directory.
+#'
+#'   Pass `user = NULL` to opt out: no `USER` directive is emitted
+#'   and the container runs as root (the previous behaviour).
+#'   Pass any other string to use that user instead of `rstudio`.
+#'   Custom homes (e.g. `/srv/myapp`) require also passing an
+#'   explicit `renv_paths_cache`.
+#'
+#'   debian/ubuntu images only (`useradd` is the standard form);
+#'   for alpine-based images you must pass `user = NULL` and handle
+#'   user creation yourself with the alpine-native `adduser`.
+#'
+#'   The argument is validated at codegen time against
+#'   `^[a-zA-Z_][a-zA-Z0-9_-]{0,31}$` (POSIX-style username, max 32
+#'   chars, no shell metacharacters). Other values raise an error
+#'   to prevent metacharacter injection into the generated `RUN`
+#'   commands.
 #' @param dependencies What kinds of dependencies to install. Most commonly
 #'   one of the following values:
 #'   - `NA`: only required (hard) dependencies,
@@ -47,11 +78,25 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   mount on the `renv::restore()` RUN; the PAT is never persisted in
 #'   the image; requires BuildKit, so pass with
 #'   `DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...`).
-#' @param renv_paths_cache character. Path used as the default of the
-#'   `RENV_PATHS_CACHE` build-arg, propagated as an `ENV` variable, and
-#'   used as the cache mount target for `renv::restore()`. Lets users
-#'   override the renv cache location at image build time via
-#'   `--build-arg RENV_PATHS_CACHE=...`.
+#' @param renv_paths_cache character or `NULL`. Path used as the
+#'   default of the `RENV_PATHS_CACHE` build-arg, propagated as an
+#'   `ENV` variable, and used as the cache mount target for
+#'   `renv::restore()`. Lets users override the renv cache location
+#'   at image build time via `--build-arg RENV_PATHS_CACHE=...`.
+#'
+#'   When `NULL` (the default), the cache path is derived from
+#'   `user`: `/root/.cache/R/renv` when `user = NULL`, and
+#'   `/home/<user>/.cache/R/renv` when `user` is a non-root username.
+#'   Pass an explicit string to override the convention (e.g. for
+#'   custom-home users like `user = "myapp"` with home at
+#'   `/srv/myapp`, pass `renv_paths_cache = "/srv/myapp/.cache/R/renv"`).
+#'
+#'   In all cases (`user = NULL` excepted), the generated Dockerfile
+#'   emits a single `RUN mkdir -p "${RENV_PATHS_CACHE}" && chown -R <user>:<user> "${RENV_PATHS_CACHE}"`
+#'   step right before the `USER <user>` directive so the cache mount
+#'   target is writable from the un-privileged user. The cache path
+#'   is double-quoted at shell expansion time so a build-arg
+#'   override containing whitespace cannot break the command.
 #' @importFrom utils getFromNamespace
 #' @return A R6 object of class `Dockerfile`.
 #' @details
@@ -86,14 +131,39 @@ dock_from_renv <- function(
   expand = FALSE,
   extra_sysreqs = NULL,
   use_pak = FALSE,
-  user = NULL,
+  user = "rstudio",
   dependencies = NA,
   sysreqs_platform = "ubuntu",
   renv_version,
   github_pat = c("none", "build_arg", "secret"),
-  renv_paths_cache = "/root/.cache/R/renv"
+  renv_paths_cache = NULL
 ) {
   github_pat <- match.arg(github_pat)
+  if (!is.null(user)) {
+    # `user` is interpolated into shell commands (id, useradd, chown, USER).
+    # Reject anything that is not a strict POSIX username so a caller passing
+    # ``"; rm -rf /"`` or ``"bad user"`` cannot inject into / break the
+    # generated Dockerfile.
+    if (
+      !is.character(user) ||
+        length(user) != 1L ||
+        !grepl("^[a-zA-Z_][a-zA-Z0-9_-]{0,31}$", user)
+    ) {
+      stop(
+        "`user` must be a single string matching the POSIX username ",
+        "regex /^[a-zA-Z_][a-zA-Z0-9_-]{0,31}$/, ",
+        "got: ",
+        deparse(user)
+      )
+    }
+  }
+  if (is.null(renv_paths_cache)) {
+    renv_paths_cache <- if (is.null(user)) {
+      "/root/.cache/R/renv"
+    } else {
+      sprintf("/home/%s/.cache/R/renv", user)
+    }
+  }
   lock <- jsonlite::read_json(
     lockfile,
     simplifyVector = TRUE,
@@ -110,12 +180,21 @@ dock_from_renv <- function(
     ),
     AS = AS
   )
+  if (!is.null(user)) {
+    dock$RUN(
+      sprintf(
+        "id -u %s >/dev/null 2>&1 || useradd -m -d /home/%s -s /bin/bash %s",
+        user,
+        user,
+        user
+      )
+    )
+  }
   .github_pat_setup(dock, github_pat)
   dock$ARG("RENV_PATHS_CACHE", default = renv_paths_cache)
   dock$ENV(key = "RENV_PATHS_CACHE", value = "${RENV_PATHS_CACHE}")
-  if (!is.null(user)) {
-    dock$USER(user)
-  }
+  # USER (if any) is emitted later, after the apt-get / R install steps
+  # that need root and after the chown of RENV_PATHS_CACHE.
   # get renv version
 
   if (missing(renv_version)) {
@@ -268,6 +347,21 @@ dock_from_renv <- function(
   }
 
   dock$COPY(basename(lockfile), "renv.lock")
+  if (!is.null(user)) {
+    # Drop privilege right before the cache-mount renv::restore RUN.
+    # The mkdir + chown make the cache target writable by `user` even
+    # though the Docker BuildKit cache mount itself is created on-demand.
+    # Single RUN with `&&` keeps the image layer count down and the
+    # quoted `"${RENV_PATHS_CACHE}"` survives a build-arg with spaces.
+    dock$RUN(
+      sprintf(
+        'mkdir -p "${RENV_PATHS_CACHE}" && chown -R %s:%s "${RENV_PATHS_CACHE}"',
+        user,
+        user
+      )
+    )
+    dock$USER(user)
+  }
   dock$RUN(
     paste0(
       "--mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} ",

--- a/man/dock_from_renv.Rd
+++ b/man/dock_from_renv.Rd
@@ -14,12 +14,12 @@ dock_from_renv(
   expand = FALSE,
   extra_sysreqs = NULL,
   use_pak = FALSE,
-  user = NULL,
+  user = "rstudio",
   dependencies = NA,
   sysreqs_platform = "ubuntu",
   renv_version,
   github_pat = c("none", "build_arg", "secret"),
-  renv_paths_cache = "/root/.cache/R/renv"
+  renv_paths_cache = NULL
 )
 }
 \arguments{
@@ -44,7 +44,37 @@ Will be installed with apt-get install.}
 
 \item{use_pak}{boolean. If \code{TRUE} use pak to deal with dependencies  during \code{renv::restore()}. FALSE by default}
 
-\item{user}{Name of the user to specify in the Dockerfile with the USER instruction. Default is \code{NULL}, in which case the user from the FROM image is used.}
+\item{user}{Name of the user the runtime container drops privilege
+to before the \code{renv::restore()} step (and therefore at runtime).
+Default is \code{"rstudio"} so the generated image runs as a non-root
+user out of the box, which is the recommended security posture.
+
+The Dockerfile is emitted in two halves: every step that needs
+root (apt-get, R install commands, \code{chown} of the renv cache)
+runs first; then a \verb{USER <user>} directive drops privilege; then
+the \code{renv::restore()} cache-mount RUN happens.
+
+To make this work regardless of the FROM image, the package
+emits a defensive \verb{RUN id -u <user> >/dev/null 2>&1 || useradd -m -d /home/<user> -s /bin/bash <user>} early. On
+rocker/* images the \code{useradd} is a no-op (the user already
+exists); on \code{r-base}, \verb{ubuntu:*}, \verb{debian:*} it creates the user
+with the standard home directory.
+
+Pass \code{user = NULL} to opt out: no \code{USER} directive is emitted
+and the container runs as root (the previous behaviour).
+Pass any other string to use that user instead of \code{rstudio}.
+Custom homes (e.g. \verb{/srv/myapp}) require also passing an
+explicit \code{renv_paths_cache}.
+
+debian/ubuntu images only (\code{useradd} is the standard form);
+for alpine-based images you must pass \code{user = NULL} and handle
+user creation yourself with the alpine-native \code{adduser}.
+
+The argument is validated at codegen time against
+\verb{^[a-zA-Z_][a-zA-Z0-9_-]\{0,31\}$} (POSIX-style username, max 32
+chars, no shell metacharacters). Other values raise an error
+to prevent metacharacter injection into the generated \code{RUN}
+commands.}
 
 \item{dependencies}{What kinds of dependencies to install. Most commonly
 one of the following values:
@@ -82,11 +112,25 @@ mount on the \code{renv::restore()} RUN; the PAT is never persisted in
 the image; requires BuildKit, so pass with
 \verb{DOCKER_BUILDKIT=1 docker build --secret id=github_pat,env=GITHUB_PAT ...}).}
 
-\item{renv_paths_cache}{character. Path used as the default of the
-\code{RENV_PATHS_CACHE} build-arg, propagated as an \code{ENV} variable, and
-used as the cache mount target for \code{renv::restore()}. Lets users
-override the renv cache location at image build time via
-\verb{--build-arg RENV_PATHS_CACHE=...}.}
+\item{renv_paths_cache}{character or \code{NULL}. Path used as the
+default of the \code{RENV_PATHS_CACHE} build-arg, propagated as an
+\code{ENV} variable, and used as the cache mount target for
+\code{renv::restore()}. Lets users override the renv cache location
+at image build time via \verb{--build-arg RENV_PATHS_CACHE=...}.
+
+When \code{NULL} (the default), the cache path is derived from
+\code{user}: \verb{/root/.cache/R/renv} when \code{user = NULL}, and
+\verb{/home/<user>/.cache/R/renv} when \code{user} is a non-root username.
+Pass an explicit string to override the convention (e.g. for
+custom-home users like \code{user = "myapp"} with home at
+\verb{/srv/myapp}, pass \code{renv_paths_cache = "/srv/myapp/.cache/R/renv"}).
+
+In all cases (\code{user = NULL} excepted), the generated Dockerfile
+emits a single \verb{RUN mkdir -p "$\{RENV_PATHS_CACHE\}" && chown -R <user>:<user> "$\{RENV_PATHS_CACHE\}"}
+step right before the \verb{USER <user>} directive so the cache mount
+target is writable from the un-privileged user. The cache path
+is double-quoted at shell expansion time so a build-arg
+override containing whitespace cannot break the command.}
 }
 \value{
 A R6 object of class \code{Dockerfile}.

--- a/tests/testthat/renv_Dockerfile
+++ b/tests/testthat/renv_Dockerfile
@@ -1,5 +1,6 @@
 FROM rocker/verse:4.1.2
-ARG RENV_PATHS_CACHE=/root/.cache/R/renv
+RUN id -u rstudio >/dev/null 2>&1 || useradd -m -d /home/rstudio -s /bin/bash rstudio
+ARG RENV_PATHS_CACHE=/home/rstudio/.cache/R/renv
 ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"
 RUN fake sys reqs
 RUN mkdir -p /usr/local/lib/R/etc/ /usr/lib/R/etc/
@@ -7,4 +8,6 @@ RUN echo "options(renv.config.pak.enabled = FALSE, repos = fake repos, download.
 RUN R -e 'install.packages("remotes")'
 RUN R -e 'remotes::install_version("renv", version = "0.0.0")'
 COPY renv.lock renv.lock
+RUN mkdir -p "${RENV_PATHS_CACHE}" && chown -R rstudio:rstudio "${RENV_PATHS_CACHE}"
+USER rstudio
 RUN --mount=type=cache,id=renv-cache,target=${RENV_PATHS_CACHE} R -e 'renv::restore()'

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -437,13 +437,16 @@ test_that("dock_from_renv emits a secret mount on restore() when github_pat = 's
 
 test_that("dock_from_renv emits the RENV_PATHS_CACHE build-arg by default", {
   skip_if(is_rdevel, "skip on R-devel")
+  # Default user is "rstudio", so the default cache is auto-derived
+  # to /home/rstudio. The build-arg, env and cache-mount tokens are
+  # locked here regardless of which user the auto-derive picks.
   out <- dock_from_renv(
     lockfile = the_lockfile,
     FROM = "rocker/verse",
     renv_version = "0.0.0"
   )
   df <- paste(out$Dockerfile, collapse = "\n")
-  expect_match(df, "ARG RENV_PATHS_CACHE=/root/.cache/R/renv", fixed = TRUE)
+  expect_match(df, "ARG RENV_PATHS_CACHE=/home/rstudio/.cache/R/renv", fixed = TRUE)
   expect_match(df, 'ENV "RENV_PATHS_CACHE"="${RENV_PATHS_CACHE}"', fixed = TRUE)
   expect_match(
     df,
@@ -568,6 +571,235 @@ test_that(".patch_rprofile_for_ppm returns invisibly when more than one Rprofile
 
   expect_null(res)
   expect_identical(dock$Dockerfile, before)
+})
+
+test_that("dock_from_renv with user = NULL keeps the cache at /root and emits no chown / no USER / no useradd", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = NULL,
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "ARG RENV_PATHS_CACHE=/root/\\.cache/R/renv")
+  expect_false(grepl("\\bUSER\\b", df))
+  expect_false(grepl("chown", df))
+  expect_false(grepl("useradd", df))
+})
+
+test_that("dock_from_renv with default user emits a defensive useradd at the top of the Dockerfile", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    renv_version = "0.0.0"
+  )
+  lines <- out$Dockerfile
+
+  # The defensive useradd must be early, well before any RUN that
+  # might touch the user. Allowing for the FROM line + a couple of
+  # ARG/ENV directives, the useradd should appear within the first
+  # few non-FROM lines.
+  useradd_idx <- grep(
+    "id -u rstudio.*useradd -m -d /home/rstudio -s /bin/bash rstudio",
+    lines
+  )
+  expect_length(useradd_idx, 1L)
+
+  # The useradd RUN must precede any chown / USER / install RUN.
+  install_idx <- grep("install\\.packages|install_version", lines)
+  user_idx <- grep("^USER ", lines)
+  if (length(install_idx) > 0L) {
+    expect_lt(useradd_idx, min(install_idx))
+  }
+  if (length(user_idx) > 0L) {
+    expect_lt(useradd_idx, min(user_idx))
+  }
+})
+
+test_that("dock_from_renv with user = 'rstudio' auto-derives the cache to /home/rstudio/", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = "rstudio",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "ARG RENV_PATHS_CACHE=/home/rstudio/\\.cache/R/renv")
+  expect_match(df, 'chown -R rstudio:rstudio "\\$\\{RENV_PATHS_CACHE\\}"')
+})
+
+test_that("dock_from_renv with user = 'rstudio' orders RUNs correctly: apt-get -> chown -> USER -> renv::restore", {
+  skip_if(is_rdevel, "skip on R-devel")
+  skip_on_os("mac")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = "rstudio",
+    renv_version = "0.0.0"
+  )
+  lines <- out$Dockerfile
+
+  apt_idx <- grep("apt-get install", lines)
+  chown_idx <- grep("chown -R rstudio:rstudio", lines)
+  user_idx <- grep("^USER rstudio$", lines)
+  restore_idx <- grep("renv::restore", lines)
+
+  expect_gt(length(chown_idx), 0L)
+  expect_gt(length(user_idx), 0L)
+  expect_gt(length(restore_idx), 0L)
+
+  # apt-get must come BEFORE USER (apt-get requires root).
+  expect_true(all(apt_idx < user_idx[1]))
+
+  # chown must come BEFORE USER (chown requires root and must
+  # run before the privilege drop).
+  expect_true(all(chown_idx < user_idx[1]))
+
+  # USER must come BEFORE renv::restore (the cache mount target
+  # was chowned to <user>; the restore needs to write to it).
+  expect_true(all(user_idx < restore_idx))
+})
+
+test_that("dock_from_renv with user + explicit renv_paths_cache honors the explicit path and chowns it", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = "myapp",
+    renv_paths_cache = "/srv/myapp/cache",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "ARG RENV_PATHS_CACHE=/srv/myapp/cache")
+  expect_match(df, 'chown -R myapp:myapp "\\$\\{RENV_PATHS_CACHE\\}"')
+})
+
+test_that("dock_from_renv rejects shell-injection-prone user values", {
+  # `user` is interpolated into Dockerfile RUN commands (id, useradd,
+  # chown). Without validation, a caller could pass a string with shell
+  # metacharacters or whitespace and either break the generated
+  # Dockerfile or inject arbitrary commands at docker build time.
+  skip_if(is_rdevel, "skip on R-devel")
+
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = "; rm -rf /",
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = "bad user",
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = "user$(echo pwned)",
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = "1starts-with-digit",
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+  # A colon would break the chown -R user:user round-trip if it ever
+  # got through the validation -- exercise it directly.
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = "foo:bar",
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+  # Non-character / wrong length must also fail with the same path.
+  expect_error(
+    dock_from_renv(
+      lockfile = the_lockfile,
+      FROM = "rocker/verse",
+      user = c("alice", "bob"),
+      renv_version = "0.0.0"
+    ),
+    "POSIX username"
+  )
+})
+
+test_that("dock_from_renv emits a single RUN combining mkdir and chown with a quoted cache path", {
+  # Two safety/hygiene properties locked here:
+  # 1. mkdir + chown must run as a single Dockerfile RUN (one image
+  #    layer) joined with `&&`.
+  # 2. The interpolated `${RENV_PATHS_CACHE}` must be double-quoted so a
+  #    build-arg containing whitespace or shell metacharacters cannot
+  #    break the command or inject (the env var is caller-overridable
+  #    via `--build-arg RENV_PATHS_CACHE=...`).
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = "rstudio",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+
+  # Single combined RUN (one layer):
+  expect_match(
+    df,
+    'RUN mkdir -p "\\$\\{RENV_PATHS_CACHE\\}" && chown -R rstudio:rstudio "\\$\\{RENV_PATHS_CACHE\\}"'
+  )
+
+  # No leftover unquoted standalone mkdir / chown:
+  expect_false(grepl("RUN mkdir -p \\$\\{RENV_PATHS_CACHE\\}\\s*$", df))
+  expect_false(
+    grepl(
+      "^RUN chown -R [^:]+:[^ ]+ \\$\\{RENV_PATHS_CACHE\\}\\s*$",
+      df,
+      perl = TRUE
+    )
+  )
+})
+
+test_that("dock_from_renv with user = 'kevin' parameterises the useradd, cache and chown on 'kevin'", {
+  # Locks the invariant that the user-handling logic is fully
+  # parameterised on `user` and not hardcoded on "rstudio". Without
+  # this, a future refactor that accidentally hardcodes the username
+  # would silently regress for any non-rstudio caller.
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    FROM = "rocker/verse",
+    user = "kevin",
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  expect_match(df, "id -u kevin >/dev/null 2>&1 \\|\\| useradd -m -d /home/kevin -s /bin/bash kevin")
+  expect_match(df, "ARG RENV_PATHS_CACHE=/home/kevin/\\.cache/R/renv")
+  expect_match(df, 'chown -R kevin:kevin "\\$\\{RENV_PATHS_CACHE\\}"')
+  # The USER directive lives on its own line; check the line vector
+  # rather than the paste-collapsed single string.
+  expect_true("USER kevin" %in% out$Dockerfile)
+  # Negative invariant: no hardcoded "rstudio" leaked into a user-scope
+  # context (cran.rstudio.com in the default repos URL is fine and
+  # excluded explicitly).
+  expect_false(any(grepl("\\brstudio\\b(?!\\.com)", out$Dockerfile, perl = TRUE)))
 })
 
 unlink(dir_build, recursive = TRUE)


### PR DESCRIPTION
## Summary

Closes #100.

Running the container as root is bad practice; the package's own
default `FROM = "rocker/r-base"` ships an `rstudio` user precisely
to make non-root operation easy. Up to now `dock_from_renv()`
required the caller to pass `user = "rstudio"` explicitly, and even
then the cache mount target was wrong (left at `/root/.cache/R/renv`
which `rstudio` cannot write to).

This PR makes `user = "rstudio"` the default and ensures the
generated Dockerfile actually works for any non-root user passed.

## Three changes, applied as a unit

### 1. Default user flips from `NULL` to `"rstudio"`

The runtime container now drops privilege to `rstudio` by default.
Pass `user = NULL` to opt out and keep the previous root behaviour.

### 2. Defensive `useradd` at the top of the Dockerfile

```dockerfile
RUN id -u <user> >/dev/null 2>&1 || useradd -m -d /home/<user> -s /bin/bash <user>
```

Idempotent: a no-op on rocker/* images where the user already
exists, a real `useradd` on `r-base`, `ubuntu:*`, `debian:*`. Works
for any user (`rstudio`, `kevin`, `myapp`, ...) on debian/ubuntu.

For alpine-based images, pass `user = NULL` and create the user
yourself (alpine uses `adduser`, not `useradd`).

### 3. Auto-derive `renv_paths_cache` and chown it before USER

`renv_paths_cache` is auto-derived from `user` when not supplied:

- `user = NULL` -> `/root/.cache/R/renv` (legacy).
- `user = "rstudio"` -> `/home/rstudio/.cache/R/renv` (new default).
- `user = "kevin"` -> `/home/kevin/.cache/R/renv`.

The Dockerfile emits an explicit
`RUN mkdir -p && chown -R <user>:<user> ${RENV_PATHS_CACHE}`
step right before the `USER <user>` directive, so the
`--mount=type=cache,target=${RENV_PATHS_CACHE}` later is writable.

The `USER` directive is moved from immediately after the ARG/ENV
setup (where it broke `apt-get` because apt-get needs root) to
right before the `renv::restore()` cache-mount RUN. All install
steps run as root; only `renv::restore()` and the runtime container
run as `<user>`.

## Behaviour change

For users regenerating their Dockerfile without specifying `user`:

```
+RUN id -u rstudio >/dev/null 2>&1 || useradd -m -d /home/rstudio ...
-ARG RENV_PATHS_CACHE=/root/.cache/R/renv
+ARG RENV_PATHS_CACHE=/home/rstudio/.cache/R/renv
 ...
+RUN mkdir -p ${RENV_PATHS_CACHE}
+RUN chown -R rstudio:rstudio ${RENV_PATHS_CACHE}
+USER rstudio
 RUN --mount=type=cache,...,target=${RENV_PATHS_CACHE} R -e 'renv::restore()'
```

## Test plan

- [x] TDD red-first: 5 new tests cover all branches.
  - user = NULL: no USER, no chown, no useradd, cache at /root.
  - default (user = "rstudio"): cache at /home/rstudio.
  - ordering invariant: apt-get -> chown -> USER -> renv::restore.
  - explicit renv_paths_cache + user: explicit path honoured, chown applied.
  - defensive useradd at the top of the Dockerfile.
- [x] Existing test `dock_from_renv works` updated; fixture
      `tests/testthat/renv_Dockerfile` regenerated.
- [x] `devtools::test()` -> [ FAIL 0 | WARN 3 | SKIP 0 | PASS 253 ].
- [x] `R CMD check --as-cran` -> 0 errors / 0 warnings / 0 notes
      (2m 45s).

## Context

Tier A item from the post-CRAN-prep roadmap. Companion to #105
(strict_install for dock_from_desc).