### PR TITLE
docs: group pkgdown Reference into thematic sections

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,6 @@ tests/testthat/.dockerignore
 ^revdep$
 ^doc$
 ^Meta$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,45 @@
+url: https://thinkr-open.github.io/dockerfiler/
+
+template:
+  bootstrap: 5
+
+reference:
+- title: "Dockerfile builders"
+  desc: >
+    High-level entry points that produce a `Dockerfile` object,
+    either from a project descriptor (DESCRIPTION, renv.lock) or
+    by parsing an existing Dockerfile. Most users start here.
+  contents:
+  - dock_from_desc
+  - dock_from_renv
+  - parse_dockerfile
+
+- title: "Dockerfile R6 class"
+  desc: >
+    Low-level imperative API for building a `Dockerfile` directive
+    by directive. The high-level builders above are thin wrappers
+    over this class.
+  contents:
+  - Dockerfile
+
+- title: "R-to-shell helper"
+  desc: >
+    Wrap an R expression into the shell-safe `R -e '...'` invocation
+    used inside a `RUN` directive.
+  contents:
+  - r
+
+- title: "System requirements"
+  desc: >
+    Resolve and compact Debian/Ubuntu system dependencies for the
+    R packages your Dockerfile installs. Usually called internally
+    by the builders; exposed for advanced use.
+  contents:
+  - get_sysreqs
+  - compact_sysreqs
+
+- title: "Project setup"
+  desc: >
+    Helpers for the surrounding project (not the Dockerfile itself).
+  contents:
+  - docker_ignore_add


### PR DESCRIPTION
## Summary

The pkgdown site auto-generated a single flat list of all exports.
With nine entries spanning three distinct conceptual layers (high-
level builders, R6 class, helpers), a new user landing on the
Reference index could not tell at a glance where to start.

This PR adds a `_pkgdown.yml` that groups the Reference index into
five small thematic sections:

- **Dockerfile builders**: `dock_from_desc`, `dock_from_renv`, `parse_dockerfile`.
- **Dockerfile R6 class**: `Dockerfile`.
- **R-to-shell helper**: `r`.
- **System requirements**: `get_sysreqs`, `compact_sysreqs`.
- **Project setup**: `docker_ignore_add`.

`_pkgdown.yml` is added to `.Rbuildignore` so it does not bloat the
package tarball; same for any future `docs/` or `pkgdown/`
directories pkgdown might generate locally.

## Test plan

- [x] `pkgdown::check_pkgdown()` clean.
- [x] All 8 NAMESPACE exports listed exactly once across the five
      sections (no missing, no double-listing).
- [x] `R CMD check --as-cran` unaffected (the new file is build-ignored).
- [x] `pr-reviewer` approve with one optional nit (the "builders"
      desc was tweaked to mention parsing, since `parse_dockerfile`
      is a deserializer rather than a builder from a descriptor).

## Context

Tier 5 polish item from the post-CRAN-prep roadmap, post-CRAN
nice-to-have. No code surface, no API change. The deployed site at
https://thinkr-open.github.io/dockerfiler/ will pick up the
grouping on next pkgdown CI run.