### PR TITLE
docs(NEWS): align renv_paths_cache bullet with post-#106 default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,10 +37,13 @@
   via `--build-arg GITHUB_PAT=$GITHUB_PAT`), or `"secret"` to use
   BuildKit secret mounts (the PAT is never persisted in image
   metadata; recommended for published images). Closes #18.
-- `dock_from_renv()` gains a `renv_paths_cache` parameter (default
-  `/root/.cache/R/renv`) used as the build-arg default, the propagated
-  `ENV` value and the cache mount target. Users can override the renv
-  cache location at image build time with
+- `dock_from_renv()` gains a `renv_paths_cache` parameter that
+  controls the `RENV_PATHS_CACHE` build-arg default, the propagated
+  `ENV` value, and the cache mount target. When `NULL` (the
+  default), the path is auto-derived from `user`:
+  `/root/.cache/R/renv` for `user = NULL`, and
+  `/home/<user>/.cache/R/renv` otherwise. Users can override the
+  renv cache location at image build time with
   `--build-arg RENV_PATHS_CACHE=...` without regenerating the
   Dockerfile.
 - `dock_from_desc()` gains a `strict_install` parameter (default


### PR DESCRIPTION
## Summary

The NEWS bullet for the `renv_paths_cache` parameter (added in
0.3.0) still described the pre-#106 behaviour:

> `dock_from_renv()` gains a `renv_paths_cache` parameter (default
> `/root/.cache/R/renv`)...

After #106 landed, the signature default flipped from a literal
string to `NULL` with auto-derivation from `user`:

- `user = NULL` -> `/root/.cache/R/renv` (legacy).
- `user = "<name>"` (default `"rstudio"`) -> `/home/<name>/.cache/R/renv`.

This PR rewrites the NEWS bullet to document the auto-derive
contract verbatim, closing the doc-runtime drift introduced when
#106 was merged.

## Test plan

- [x] No code, NAMESPACE, Rd, or test change. Diff = single bullet
      rewrite in NEWS.md.
- [x] Cross-checked the rewritten bullet against `R/dock_from_renv.R`
      signature (line 139), auto-derive branch (lines 160-166),
      ARG/ENV emission (line 194), and cache mount target (line 367)
      via pr-reviewer agent.
- [x] No em/en-dashes; style matches surrounding "New features"
      bullets.

## Context

Surfaced during the post-merge sanity check on master 0.3.0.
Tier-zero polish before the CRAN release sequence.