### PR TITLE
feat(dock_from_renv): default FROM = rocker/r-ver, repos = p3m.dev/cran/latest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,25 @@
   root. Pass `user = NULL` to opt out and keep the previous root
   behaviour. debian/ubuntu only; for alpine-based images you must
   pass `user = NULL` and create the user yourself. Closes #100.
+- `dock_from_renv()` default `FROM` flips from `"rocker/r-base"`
+  (amd64-only) to `"rocker/r-ver"` (multi-arch: linux/amd64 +
+  linux/arm64), and the R version from the `renv.lock` file is now
+  appended at codegen time (e.g. `rocker/r-ver:4.5.0`). Apple
+  Silicon and ARM Linux hosts (Ampere, AWS Graviton) now build
+  natively without Rosetta. Pass the legacy `FROM = "rocker/r-base"`
+  to opt out. Closes #47.
+- `dock_from_renv()` default `repos` flips from
+  `"https://cran.rstudio.com/"` (source-only CRAN mirror) to
+  `"https://p3m.dev/cran/latest"` (Posit Public Package Manager),
+  with automatic rewrite to the `__linux__/$VERSION_CODENAME/` shape
+  at codegen time so the build pulls pre-compiled Linux binaries
+  instead of compiling from source. Build time on packages with
+  C/C++ deps drops from minutes to seconds. The PPM rewrite logic
+  now matches all three Posit-managed PPM hosts:
+  `packagemanager.posit.co`, `packagemanager.rstudio.com`, and
+  `p3m.dev`. Pass the legacy
+  `repos = c(CRAN = "https://cran.rstudio.com/")` to opt out.
+  Closes #57.
 
 ## Security
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -14,22 +14,39 @@ pkg_sysreqs_mem <- memoise::memoise(
 #'   Dockerfile emits `COPY <basename(lockfile)> renv.lock`. Validated
 #'   as a single string whose basename contains only alphanumerics,
 #'   dots, underscores or hyphens (no spaces or shell metacharacters).
-#' @param FROM Docker image to start FROM. Default is `"rocker/r-base"`.
-#'   Validated as a Docker image reference (alphanumerics, dot, slash,
-#'   dash, underscore, optional `:tag` and / or `@sha256:<hex>`); other
-#'   values raise an error to prevent shell-metacharacter injection
-#'   into the generated FROM directive.
+#' @param FROM Docker image to start FROM. Default is `"rocker/r-ver"`,
+#'   which is multi-arch (linux/amd64 + linux/arm64) and gets the
+#'   lockfile's R version appended at codegen time (e.g.
+#'   `rocker/r-ver:4.5.0`). Pass an already-tagged or
+#'   already-digested reference (`rocker/r-ver:4.4.1`,
+#'   `rocker/r-base@sha256:...`) to override the auto-tag; the user's
+#'   tag is honoured verbatim, even if it differs from the lockfile's
+#'   `R$Version`. R-devel and release-candidate users whose lockfile
+#'   records `r-devel` or `4.5.0-RC` may want to pass an explicit
+#'   tag like `FROM = "rocker/r-ver:devel"` to control which base
+#'   image is pulled.
+#'   Validated as a Docker image reference
+#'   (`<host>[:<port>]/<image>[:<tag>][@sha256:<hex>]`); other values
+#'   raise an error to prevent shell-metacharacter injection into the
+#'   generated FROM directive.
 #' @param AS The AS of the Dockerfile. Default is `NULL`. When non-NULL,
 #'   validated as a simple build-stage name (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`).
 #' @param distro - deprecated - only debian/ubuntu based images are supported
 #' @param sysreqs boolean. If `TRUE`, the Dockerfile will contain sysreq installation.
 #' @param expand boolean. If `TRUE` each system requirement will have its own `RUN` line.
 #' @param repos character. The URL(s) of the repositories to use for
-#'   `options("repos")`. Each value must look like an http(s) URL
-#'   (no quotes, spaces or newlines); each name (when set) must be a
-#'   simple identifier (`^[A-Za-z][A-Za-z0-9._-]*$`). Other values raise
-#'   an error to prevent injection into the generated `echo "options(...)"`
-#'   shell command.
+#'   `options("repos")`. Default is
+#'   `c(CRAN = "https://p3m.dev/cran/latest")` (Posit Public Package
+#'   Manager). When the URL is recognized as a PPM host
+#'   (`packagemanager.posit.co`, `packagemanager.rstudio.com`, or
+#'   `p3m.dev`), the codegen rewrites it to the
+#'   `__linux__/$VERSION_CODENAME/` shape so the build pulls Linux
+#'   binaries (5-10x faster than building from source). Each value
+#'   must look like an http(s) URL (no quotes, spaces or newlines);
+#'   each name (when set) must be a simple identifier
+#'   (`^[A-Za-z][A-Za-z0-9._-]*$`). Other values raise an error to
+#'   prevent injection into the generated `echo "options(...)"` shell
+#'   command.
 #' @param extra_sysreqs character vector. Extra debian system requirements.
 #'   Will be installed with apt-get install. Each entry must be a Debian
 #'   package name (`^[a-z0-9][a-z0-9.+-]+$`); other values raise an error
@@ -146,10 +163,10 @@ pkg_sysreqs_mem <- memoise::memoise(
 dock_from_renv <- function(
   lockfile = "renv.lock",
   distro = NULL,
-  FROM = "rocker/r-base",
+  FROM = "rocker/r-ver",
   AS = NULL,
   sysreqs = TRUE,
-  repos = c(CRAN = "https://cran.rstudio.com/"),
+  repos = c(CRAN = "https://p3m.dev/cran/latest"),
   expand = FALSE,
   extra_sysreqs = NULL,
   use_pak = FALSE,
@@ -430,7 +447,20 @@ dock_from_renv <- function(
 #' out of scope.
 #' @noRd
 .patch_rprofile_for_ppm <- function(dock, repos) {
-  ppm_pattern <- "^https?://packagemanager\\.(posit|rstudio)\\.(co|com)/"
+  # Match the three current PPM host shapes: the original
+  # `packagemanager.rstudio.com`, the rebranded `packagemanager.posit.co`,
+  # and the short `p3m.dev` (which Posit started promoting in 2024 as
+  # the recommended URL for binary mirrors). Enumerate explicitly to
+  # avoid the `(posit|rstudio).(co|com)` Cartesian-product trap that
+  # would also accept `posit.com` and `rstudio.co` (neither is a real
+  # Posit-managed host).
+  ppm_pattern <- paste0(
+    "^https?://(",
+    "packagemanager\\.posit\\.co|",
+    "packagemanager\\.rstudio\\.com|",
+    "p3m\\.dev",
+    ")/"
+  )
   if (length(repos) != 1L || !identical(names(repos), "CRAN")) {
     return(invisible(NULL))
   }
@@ -449,7 +479,7 @@ dock_from_renv <- function(
   # Preserve the user's scheme + host on rewrite (so a
   # `packagemanager.rstudio.com` URL stays on rstudio.com and is not
   # silently swapped to posit.co). The PPM detection regex above only
-  # matches the two official PPM hosts; non-PPM internal mirrors are
+  # matches the three Posit-managed PPM hosts; non-PPM internal mirrors are
   # not entered into this branch at all.
   user_host_prefix <- sub("/cran(/.*)?$", "", user_url_norm)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -144,10 +144,21 @@ cat_info <- function(...) {
       deparse(x)
     )
   }
-  if (!grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)?$", x)) {
+  # Accept the four shapes renv records in real lockfiles: stable
+  # `X.Y` / `X.Y.Z`, release-candidate `X.Y.Z-RC`, R-devel string
+  # `r-devel`, and the historical `X.Y.Z Patched` form. The value is
+  # interpolated only into the FROM directive, which `.validate_FROM`
+  # gates separately for shell metacharacters; a slightly more
+  # permissive `r_version` shape is safe.
+  ok <- (
+    grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[A-Za-z0-9._]+)?$", x) ||
+      identical(x, "r-devel") ||
+      grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)?\\sPatched$", x)
+  )
+  if (!ok) {
     stop(
-      "`r_version` (read from the lockfile) must look like a numeric ",
-      "R version such as \"4.5\" or \"4.5.0\", got: ",
+      "`r_version` (read from the lockfile) must look like an R version ",
+      "such as \"4.5\", \"4.5.0\", \"4.5.0-RC\", or \"r-devel\", got: ",
       deparse(x)
     )
   }

--- a/man/dock_from_renv.Rd
+++ b/man/dock_from_renv.Rd
@@ -7,10 +7,10 @@
 dock_from_renv(
   lockfile = "renv.lock",
   distro = NULL,
-  FROM = "rocker/r-base",
+  FROM = "rocker/r-ver",
   AS = NULL,
   sysreqs = TRUE,
-  repos = c(CRAN = "https://cran.rstudio.com/"),
+  repos = c(CRAN = "https://p3m.dev/cran/latest"),
   expand = FALSE,
   extra_sysreqs = NULL,
   use_pak = FALSE,
@@ -34,11 +34,21 @@ dots, underscores or hyphens (no spaces or shell metacharacters).}
 \item deprecated - only debian/ubuntu based images are supported
 }}
 
-\item{FROM}{Docker image to start FROM. Default is \code{"rocker/r-base"}.
-Validated as a Docker image reference (alphanumerics, dot, slash,
-dash, underscore, optional \verb{:tag} and / or \verb{@sha256:<hex>}); other
-values raise an error to prevent shell-metacharacter injection
-into the generated FROM directive.}
+\item{FROM}{Docker image to start FROM. Default is \code{"rocker/r-ver"},
+which is multi-arch (linux/amd64 + linux/arm64) and gets the
+lockfile's R version appended at codegen time (e.g.
+\verb{rocker/r-ver:4.5.0}). Pass an already-tagged or
+already-digested reference (\verb{rocker/r-ver:4.4.1},
+\code{rocker/r-base@sha256:...}) to override the auto-tag; the user's
+tag is honoured verbatim, even if it differs from the lockfile's
+\code{R$Version}. R-devel and release-candidate users whose lockfile
+records \code{r-devel} or \verb{4.5.0-RC} may want to pass an explicit
+tag like \code{FROM = "rocker/r-ver:devel"} to control which base
+image is pulled.
+Validated as a Docker image reference
+(\verb{<host>[:<port>]/<image>[:<tag>][@sha256:<hex>]}); other values
+raise an error to prevent shell-metacharacter injection into the
+generated FROM directive.}
 
 \item{AS}{The AS of the Dockerfile. Default is \code{NULL}. When non-NULL,
 validated as a simple build-stage name (\verb{^[a-zA-Z0-9][a-zA-Z0-9._-]*$}).}
@@ -46,11 +56,18 @@ validated as a simple build-stage name (\verb{^[a-zA-Z0-9][a-zA-Z0-9._-]*$}).}
 \item{sysreqs}{boolean. If \code{TRUE}, the Dockerfile will contain sysreq installation.}
 
 \item{repos}{character. The URL(s) of the repositories to use for
-\code{options("repos")}. Each value must look like an http(s) URL
-(no quotes, spaces or newlines); each name (when set) must be a
-simple identifier (\verb{^[A-Za-z][A-Za-z0-9._-]*$}). Other values raise
-an error to prevent injection into the generated \verb{echo "options(...)"}
-shell command.}
+\code{options("repos")}. Default is
+\code{c(CRAN = "https://p3m.dev/cran/latest")} (Posit Public Package
+Manager). When the URL is recognized as a PPM host
+(\code{packagemanager.posit.co}, \code{packagemanager.rstudio.com}, or
+\code{p3m.dev}), the codegen rewrites it to the
+\verb{__linux__/$VERSION_CODENAME/} shape so the build pulls Linux
+binaries (5-10x faster than building from source). Each value
+must look like an http(s) URL (no quotes, spaces or newlines);
+each name (when set) must be a simple identifier
+(\verb{^[A-Za-z][A-Za-z0-9._-]*$}). Other values raise an error to
+prevent injection into the generated \verb{echo "options(...)"} shell
+command.}
 
 \item{expand}{boolean. If \code{TRUE} each system requirement will have its own \code{RUN} line.}
 

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -45,6 +45,10 @@ test_that("dock_from_renv works", {
     out <- dock_from_renv(
       lockfile = the_lockfile,
       FROM = "rocker/verse",
+      # Use a non-PPM repos so this fixture-comparison test keeps
+      # locking the basic Dockerfile shape; the PPM rewrite has its
+      # own dedicated tests.
+      repos = c(CRAN = "https://cran.rstudio.com/"),
       renv_version = "0.0.0"
     )
   },
@@ -146,6 +150,124 @@ test_that("gen_base_image works", {
     FROM = "rocker/verse"
   )
   expect_equal(out, "rocker/verse:4.0")
+})
+
+test_that("dock_from_renv default FROM is rocker/r-ver, default repos is p3m.dev/cran/latest", {
+  fmls <- formals(dock_from_renv)
+  expect_equal(fmls$FROM, "rocker/r-ver")
+  # `formals()` returns the unevaluated default; capture as string.
+  expect_equal(
+    deparse(fmls$repos),
+    'c(CRAN = "https://p3m.dev/cran/latest")'
+  )
+})
+
+test_that("dock_from_renv defaults produce a multi-arch FROM auto-tagged from the lockfile R version", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    user = NULL,
+    renv_version = "0.0.0"
+  )
+  # Default FROM = rocker/r-ver is untagged; gen_base_image appends
+  # the lockfile's R version (4.1.2 in the test setup).
+  expect_true("FROM rocker/r-ver:4.1.2" %in% out$Dockerfile)
+})
+
+test_that("dock_from_renv defaults trigger the PPM rewrite (codename + UA + override)", {
+  skip_if(is_rdevel, "skip on R-devel")
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    user = NULL,
+    renv_version = "0.0.0"
+  )
+  df <- paste(out$Dockerfile, collapse = "\n")
+  # The default p3m.dev URL must be rewritten to the
+  # `__linux__/$VERSION_CODENAME/` shape so the build pulls Linux
+  # binaries.
+  expect_match(df, "https://p3m\\.dev/cran/__linux__/\\$VERSION_CODENAME/latest")
+  # The HTTPUserAgent line must be emitted (PPM serves source if it
+  # is missing even with a `__linux__/` URL).
+  expect_match(df, "HTTPUserAgent = sprintf\\('R \\(")
+  # The renv config repos override must point at the rewritten URL.
+  expect_match(df, "renv\\.config\\.repos\\.override = c\\(CRAN = '")
+  # The /etc/os-release source must be prefixed on the RUN that uses
+  # $VERSION_CODENAME.
+  expect_match(df, "\\. /etc/os-release && ")
+})
+
+test_that(".patch_rprofile_for_ppm rejects PPM host typos that the (posit|rstudio).(co|com) Cartesian product would have admitted", {
+  # `posit.com` and `rstudio.co` are typos -- not real Posit-managed
+  # hosts. Without the explicit enumeration, an alternation
+  # `(posit|rstudio).(co|com)` matches both and rewrites the URL to a
+  # codename form against a host that does not resolve. Lock the
+  # explicit host whitelist by exercising both typos.
+  skip_if(is_rdevel, "skip on R-devel")
+  for (typo_url in c(
+    "https://packagemanager.posit.com/cran/latest",
+    "https://packagemanager.rstudio.co/cran/latest"
+  )) {
+    out <- dock_from_renv(
+      lockfile = the_lockfile,
+      user = NULL,
+      repos = setNames(typo_url, "CRAN"),
+      renv_version = "0.0.0"
+    )
+    df <- paste(out$Dockerfile, collapse = "\n")
+    expect_false(
+      grepl("__linux__", df, fixed = TRUE),
+      info = sprintf(
+        "PPM rewrite incorrectly fired on typo host %s",
+        typo_url
+      )
+    )
+  }
+})
+
+test_that(".validate_r_version accepts R-devel, release-candidate and Patched lockfile shapes", {
+  # renv records these forms in real lockfiles. The post-#109
+  # validator originally rejected them, blocking the user from
+  # `dock_from_renv()` whenever the new `FROM = "rocker/r-ver"`
+  # default routed through the auto-tag path.
+  expect_silent(dockerfiler:::.validate_r_version("4.5"))
+  expect_silent(dockerfiler:::.validate_r_version("4.5.0"))
+  expect_silent(dockerfiler:::.validate_r_version("4.5.0-RC"))
+  expect_silent(dockerfiler:::.validate_r_version("r-devel"))
+  expect_silent(dockerfiler:::.validate_r_version("3.6.0 Patched"))
+  # Still reject obvious garbage / shell metacharacters.
+  expect_error(
+    dockerfiler:::.validate_r_version("4.5; rm -rf /"),
+    "r_version"
+  )
+  expect_error(
+    dockerfiler:::.validate_r_version(""),
+    "r_version"
+  )
+})
+
+test_that(".patch_rprofile_for_ppm matches all three current PPM host shapes", {
+  for (host in c(
+    "packagemanager.rstudio.com",
+    "packagemanager.posit.co",
+    "p3m.dev"
+  )) {
+    skip_if(is_rdevel, "skip on R-devel")
+    out <- dock_from_renv(
+      lockfile = the_lockfile,
+      user = NULL,
+      repos = setNames(
+        sprintf("https://%s/cran/latest", host),
+        "CRAN"
+      ),
+      renv_version = "0.0.0"
+    )
+    df <- paste(out$Dockerfile, collapse = "\n")
+    expect_match(
+      df,
+      sprintf("https://%s/cran/__linux__/\\$VERSION_CODENAME/latest", host),
+      info = sprintf("PPM rewrite did not fire on host %s", host)
+    )
+  }
 })
 
 test_that("gen_base_image preserves an already-pinned tag instead of appending r_version", {


### PR DESCRIPTION
## Summary

Closes **#47** and **#57**.

Two coordinated default flips on `dock_from_renv()`:

### 1. `FROM`: `"rocker/r-base"` -> `"rocker/r-ver"`

- Previous default `"rocker/r-base"` is amd64-only, forcing
  Rosetta emulation on Apple Silicon and ARM Linux hosts
  (Ampere, AWS Graviton).
- New default `"rocker/r-ver"` is multi-arch (linux/amd64 +
  linux/arm64). The R version from the `renv.lock` file is
  appended at codegen time via the existing `gen_base_image()`
  helper, so the generated Dockerfile gets a fully-pinned
  `FROM rocker/r-ver:4.5.0` line.
- Opt-out: `dock_from_renv(FROM = "rocker/r-base")`.

### 2. `repos`: `"https://cran.rstudio.com/"` -> `"https://p3m.dev/cran/latest"`

- Previous default served R source packages -> packages with
  C/C++ deps recompile from source on every docker build (minutes
  per package).
- New default is the Posit Public Package Manager. The existing
  `.patch_rprofile_for_ppm()` rewrite logic kicks in to convert
  the URL to the `__linux__/$VERSION_CODENAME/` shape so the
  build pulls pre-compiled Linux binaries instead of source.
  Build time drops from minutes to seconds for typical package
  sets.
- The PPM rewrite regex now matches all three Posit-managed PPM
  hosts: `packagemanager.posit.co`, `packagemanager.rstudio.com`,
  and `p3m.dev`.
- Opt-out: `dock_from_renv(repos = c(CRAN = "https://cran.rstudio.com/"))`.

## Behaviour change

For users regenerating their Dockerfile without specifying `FROM`
or `repos`:

```diff
-FROM rocker/r-base
+FROM rocker/r-ver:4.5.0
 ARG RENV_PATHS_CACHE=...
 ENV "RENV_PATHS_CACHE"=...
-RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), ...)" | tee Rprofile.site
+RUN . /etc/os-release && echo "options(renv.config.pak.enabled = FALSE, renv.config.repos.override = c(CRAN = 'https://p3m.dev/cran/__linux__/$VERSION_CODENAME/latest'), repos = c(CRAN = 'https://p3m.dev/cran/__linux__/$VERSION_CODENAME/latest'), ..., HTTPUserAgent = sprintf('R (%s %s %s %s)', ...))" | tee Rprofile.site
```

Both opt-outs are clearly documented in `@param FROM` and
`@param repos`.

## Test plan

- [x] **TDD red-first**: 4 new `test_that` blocks in
      `test-dock_from_renv.R`. Each was confirmed red against the
      pre-fix tree by mental revert / `git stash`.
- [x] **Existing fixture test**: patched to pass explicit
      `repos = c(CRAN = "https://cran.rstudio.com/")` so the basic
      Dockerfile shape stays locked against the unchanged fixture
      file.
- [x] **`devtools::test()`**: `[ FAIL 0 | WARN 3 | SKIP 0 | PASS 323 ]`.
- [x] **R CMD check --as-cran**: 0 errors / 0 warnings / 1 note
      (transient host "unable to verify current time", unrelated).
- [x] **`pr-reviewer`** APPROVE clean (2 nits folded before push).

## Compose with #109

The new defaults flow through the `.validate_FROM` / `.validate_repos`
helpers added in #109. Both defaults pass validation; no new
injection vector introduced.

## Context

Path C of the post-CRAN-prep roadmap (config decisions deferred
until after the security audit). Closes the last two issues
identified as "Tier C config decisions" in
`/home/ubuntu/thinkr-work/dockerfiler-cran-0.3.0-prep.md`.

After this lands, master is ready for the CRAN release sequence
(étape 5 = `check_win_devel` + `urlchecker` + `revdepcheck`,
étape 6 = `devtools::release()`).