### PR TITLE
chore: keep Colin Fay as the package maintainer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,9 @@ Package: dockerfiler
 Title: Easy Dockerfile Creation from R
 Version: 0.3.0
 Authors@R: c(
-    person("Colin", "Fay", , "contact@colinfay.me", role = "aut",
+    person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),
-    person("Vincent", "Guyader", , "vincent@thinkr.fr", role = c("cre", "aut"),
+    person("Vincent", "Guyader", , "vincent@thinkr.fr", role = "aut",
            comment = c(ORCID = "0000-0003-0671-9270")),
     person("Josiah", "Parry", , "josiah.parry@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-9910-865X")),

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -20,15 +20,6 @@ clock skew on the build VM; the package itself is unaffected.)
   CRAN submission; the win-builder result will follow by email
   and will be forwarded to CRAN if it surfaces anything new.
 
-## Maintainer change
-
-This release changes the maintainer from Colin Fay
-(`contact@colinfay.me`) to Vincent Guyader
-(`vincent@thinkr.fr`). Both remain listed as authors. The
-previous maintainer (Colin Fay) is aware of this submission and
-will confirm the maintainer change by replying to the automated
-email from CRAN's submission system.
-
 ## Major changes since 0.2.6
 
 A focused 0.3.0 release. Headline bullets (full details in


### PR DESCRIPTION
## Summary

Reverts the maintainer (`cre`) swap from #111. Per Vincent's call, Colin Fay (`contact@colinfay.me`) stays the maintainer for the 0.3.0 CRAN submission; Vincent Guyader goes back to `aut`. Both remain listed as authors, ORCIDs unchanged.

`cran-comments.md`: the "Maintainer change" section is removed — there is no maintainer change, so CRAN's submission system will not emit a "New maintainer" note.

## Changes

- `DESCRIPTION`: `Colin Fay` → `role = c("cre", "aut")`, `Vincent Guyader` → `role = "aut"`.
- `cran-comments.md`: drop the `## Maintainer change` section.

No R code, no NAMESPACE, no Rd, no test impact.

## Test plan

- [x] Authors@R well-formed (4 persons, one `cre`, ORCIDs intact).
- [ ] `R CMD check --as-cran`: expecting 0/0/0 (one transient host-clock NOTE), running.
- This is a 2-file metadata/docs PR; CI green is the gate.