### PR TITLE
docs: fold in Copilot's #115 review nits + restore lost VignetteIndexEntry

### DIFF
--- a/R/rthis.R
+++ b/R/rthis.R
@@ -12,7 +12,7 @@
 #'
 #' @examples
 #' r(print("yeay"))
-#' r(install.packages("plumber", repos = "http://cran.irsn.fr/"))
+#' r(install.packages("plumber", repos = "https://cloud.r-project.org"))
 r <- function(code) {
   code <- paste(trimws(deparse(substitute(code))), collapse = " ")
   glue("R -e {shQuote(code, type = 'sh')}")

--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,7 @@ my_dock$COMMENT("Install required R package.")
 Wrap your raw R Code inside the `r()` function to turn it into a bash command with `R -e`.
 
 ```{r}
-my_dock$RUN(r(install.packages("attempt", repos = "http://cran.irsn.fr/")))
+my_dock$RUN(r(install.packages("attempt", repos = "https://cloud.r-project.org")))
 ```
 
 Classical Docker stuffs:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Wrap your raw R Code inside the `r()` function to turn it into a bash
 command with `R -e`.
 
 ``` r
-my_dock$RUN(r(install.packages("attempt", repos = "http://cran.irsn.fr/")))
+my_dock$RUN(r(install.packages("attempt", repos = "https://cloud.r-project.org")))
 ```
 
 Classical Docker stuffs:

--- a/man/r.Rd
+++ b/man/r.Rd
@@ -20,5 +20,5 @@ shell-quoted \verb{R -e '...'} string, suitable for a \link{Dockerfile}
 }
 \examples{
 r(print("yeay"))
-r(install.packages("plumber", repos = "http://cran.irsn.fr/"))
+r(install.packages("plumber", repos = "https://cloud.r-project.org"))
 }

--- a/vignettes/dockerfiler.Rmd
+++ b/vignettes/dockerfiler.Rmd
@@ -4,7 +4,7 @@ author: "Colin Fay"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{getting_started}
+  %\VignetteIndexEntry{Getting started with dockerfiler}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -53,7 +53,7 @@ my_dock$MAINTAINER("Colin FAY", "contact@colinfay.me")
 Wrap your raw R Code inside the `r()` function to turn it into a bash command with `R -e`.
 
 ```{r}
-my_dock$RUN(r(install.packages("attempt", repos = "http://cran.irsn.fr/")))
+my_dock$RUN(r(install.packages("attempt", repos = "https://cloud.r-project.org")))
 ```
 
 Classical Docker stuffs:
@@ -131,7 +131,7 @@ pulls Linux binaries from Posit Public Package Manager
 (`https://p3m.dev/cran/latest`). Pass `FROM = "rocker/r-base"` or
 `repos = c(CRAN = "https://cran.rstudio.com/")` to opt out.
 
-## Create a Dockerfile from an renv.lock
+## Create a Dockerfile from a renv.lock
 
 If your project uses `{renv}`, `dock_from_renv()` turns the `renv.lock`
 into a Dockerfile that restores the exact pinned versions.


### PR DESCRIPTION
## Summary

Follow-up to #115. Two things:

1. **Restore the `%\VignetteIndexEntry{Getting started with dockerfiler}` fix** that was lost: #115 was merged from `437c48a`, before the `2dcdc73` force-push that aligned the vignette's `\VignetteIndexEntry{}` to its YAML `title:`. Without it, rmarkdown emits a title-mismatch warning when rendering the vignette.

2. **Fold in Copilot's three inline comments on #115**:
   - `vignettes/dockerfiler.Rmd`: heading "Create a Dockerfile from **an** renv.lock" → "... from **a** renv.lock".
   - `R/rthis.R` `@examples`, `vignettes/dockerfiler.Rmd` "Basic workflow" chunk, and `README.Rmd`: the illustrative `install.packages(..., repos = "http://cran.irsn.fr/")` now uses CRAN's canonical HTTPS mirror `https://cloud.r-project.org` instead of a plaintext-HTTP regional mirror.

`man/r.Rd` regenerated; `README.md` re-knit. No code-logic change.

## Verification
- `devtools::test()` on `test-r.R`: 0 failures.
- Vignette renders clean (no title-mismatch warning).
- No `cran.irsn.fr` left anywhere; no en/em-dashes in source.
- (copilot-feedback triaged the 3 comments as partially-valid — the http→https framing as "insecure" is overstated since `R CMD check --as-cran` doesn't check URLs inside `\examples{}`, but it's a real hygiene improvement; factorized into `pr-reviewer.md` check #42.)

## Test plan
- [ ] CI green.
- [ ] Copilot review (should be clean — these address its prior comments).