### PR TITLE
chore: bump to 1.0.0 for the first major release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dockerfiler
 Title: Easy Dockerfile Creation from R
-Version: 0.3.0
+Version: 1.0.0
 Authors@R: c(
     person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-# dockerfiler 0.3.0
+# dockerfiler 1.0.0
+
+First major release. The version is bumped to 1.0.0 to signal API
+maturity after a stabilisation cycle that overhauled the
+input-validation surface, hardened the codegen against `renv.lock` /
+`DESCRIPTION` injection, removed the vendored copy of `{renv}`, and
+flipped the high-level generators' defaults to multi-arch
+`rocker/r-ver` + binary packages from Posit Public Package Manager.
+See below.
 
 ## Breaking changes
 
@@ -64,9 +72,9 @@
   line without passing through `.validate_renv_version()`. A crafted
   `renv.lock` could break out of the inner R string and execute
   arbitrary code as root at `docker build` time. The user-supplied
-  `renv_version=` argument has been validated since the 0.3.0
+  `renv_version=` argument has been validated since the 1.0.0
   shell-context hardening above, but the lockfile-fallback path was
-  missed; the bug itself predates 0.3.0 (it existed while the
+  missed; the bug itself predates 1.0.0 (it existed while the
   vendored `{renv}` parser was in use). The validator is now applied
   to the resolved value whatever its source. Found by an internal
   security audit before release.
@@ -89,7 +97,7 @@
   via the `remotes::install_version("<name>", ...)` install RUNs on
   the default `build_from_source = TRUE` path. Both the package name
   and every dependency-field name are now validated against the CRAN
-  package-name grammar at function entry. The bug predates 0.3.0.
+  package-name grammar at function entry. The bug predates 1.0.0.
   Found by the same internal security audit as the `dock_from_renv()`
   fix above.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You’re reading the doc about version :
 
 ``` r
 desc::desc_get_version()
-#> [1] '0.3.0'
+#> [1] '1.0.0'
 ```
 
 ## Installation

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -20,10 +20,11 @@ clock skew on the build VM; the package itself is unaffected.)
   CRAN submission; the win-builder result will follow by email
   and will be forwarded to CRAN if it surfaces anything new.
 
-## Major changes since 0.2.6
+## Major changes in 1.0.0
 
-A focused 0.3.0 release. Headline bullets (full details in
-`NEWS.md`):
+First major release. Version bumped from the 0.2.x development line
+to 1.0.0 to signal API maturity after the stabilisation cycle
+described below. Headline bullets (full details in `NEWS.md`):
 
 ### Breaking changes
 
@@ -91,7 +92,7 @@ A focused 0.3.0 release. Headline bullets (full details in
   as root at `docker build` time. The validator is now applied
   to the resolved value whatever its source. (The bug predates
   this release; no published `{dockerfiler}` version carried the
-  0.3.0 changeset, so there is nothing to coordinate with CRAN
+  1.0.0 changeset, so there is nothing to coordinate with CRAN
   beyond noting it here.)
 
 ### Bug fixes
@@ -116,7 +117,7 @@ local `{golem}` checkout was additionally grepped explicitly:
 the only `dockerfiler` references are to the public API
 (`dock_from_renv`, `dock_from_desc`, `Dockerfile`,
 `get_sysreqs`), whose signatures are preserved across this
-release. The other 0.3.0 changes (default flip of `FROM` to
+release. The other 1.0.0 changes (default flip of `FROM` to
 `rocker/r-ver`, of `repos` to `p3m.dev/cran/latest`, and of
 `user` to `"rstudio"`) are behavioural-default changes and do
 not break downstream call sites.


### PR DESCRIPTION
## Summary

Renames the unreleased 0.3.0 development line to **1.0.0** for the upcoming CRAN submission.

## Changes

- **`DESCRIPTION`** — `Version: 0.3.0` → `1.0.0`.
- **`NEWS.md`** — section header `# dockerfiler 0.3.0` → `# dockerfiler 1.0.0`, with a short lead paragraph explaining why a major-version bump (API maturity after this cycle's input-validation family, codegen hardening against `renv.lock` / `DESCRIPTION` injection, vendored-renv removal, multi-arch / PPM-binaries defaults). The three internal "since the 0.3.0 hardening" / "predates 0.3.0" pointers inside the Security bullets are updated to "1.0.0".
- **`cran-comments.md`** — section header `## Major changes since 0.2.6` → `## Major changes in 1.0.0` (with a one-line note that this is the first major release after the 0.2.x dev line); the three "0.3.0" mentions in the body retargeted to "1.0.0".
- **`README.md`** — re-knit (the live `desc::desc_get_version()` chunk picks up `[1] '1.0.0'`).

No R code, no NAMESPACE, no Rd, no test impact (the `"Version: 1.0.0"` strings in `tests/testthat/test-dock_from_desc.R` are unrelated test-DESCRIPTION fixtures).

## Test plan

- [x] No remaining `0.3.0` occurrence anywhere in source (`grep -rn 0\.3\.0` is empty).
- [x] `README.md` shows `[1] '1.0.0'`.
- [x] Targeted test file (`test-r.R`) still passes.
- [ ] CI green.