### PR TITLE
docs: silence devtools::document() roxygen link warnings

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -39,7 +39,7 @@ cat_info <- function(...) {
 #' default) and an `ENV GITHUB_PAT=${GITHUB_PAT}` propagation so any
 #' subsequent RUN inherits the value. For `"none"` and `"secret"`, no
 #' top-level directive is emitted (in `"secret"` mode the secret is
-#' mounted RUN-by-RUN by [.github_pat_run_prefix()]).
+#' mounted RUN-by-RUN by `.github_pat_run_prefix()`).
 #' Side-effects only: modifies `dock` in place.
 #' @noRd
 .github_pat_setup <- function(dock, mode) {
@@ -54,7 +54,7 @@ cat_info <- function(...) {
 #'
 #' Returns a string to prepend to a RUN command body. Empty string for
 #' modes `"none"` and `"build_arg"` (the latter relies on the ENV set
-#' by [.github_pat_setup()]); a `--mount=type=secret,...` fragment plus
+#' by `.github_pat_setup()`); a `--mount=type=secret,...` fragment plus
 #' a shell `GITHUB_PAT=$(cat ...)` prefix for mode `"secret"`.
 #'
 #' The file-read pattern (`cat /run/secrets/github_pat`) is preferred


### PR DESCRIPTION
## Summary

Silences the two long-standing `devtools::document()` warnings:

```
✖ utils.R:38: @description Could not resolve link to topic ".github_pat_run_prefix"
✖ utils.R:55: @description Could not resolve link to topic ".github_pat_setup"
```

Cause: the two internal helpers `.github_pat_setup()` / `.github_pat_run_prefix()` are `@noRd`, so no `.Rd` is generated; their `@description` blocks cross-reference each other via `[.github_pat_X()]` markdown links, which roxygen then can't resolve.

Fix: switch the references from markdown links to plain backticks (`` `.github_pat_X()` ``). Prose stays explanatory, no link is attempted, no warning.

## Diff

- `R/utils.R:42`: `` [.github_pat_run_prefix()] `` → `` `.github_pat_run_prefix()` ``
- `R/utils.R:57`: `` [.github_pat_setup()] `` → `` `.github_pat_setup()` ``

No `.Rd` change (the affected helpers are `@noRd`), no NAMESPACE change, no behaviour change. `devtools::document()` is now clean.

## Test plan

- [x] `devtools::document()`: no warnings.
- [ ] CI green.